### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -6,6 +6,9 @@ on:
     - cron: "17 3 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
Potential fix for [https://github.com/cadmpeg/cadmpeg/security/code-scanning/1](https://github.com/cadmpeg/cadmpeg/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/fuzz-smoke.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal and appropriate permission is:

- `contents: read`

This supports `actions/checkout` and does not grant unnecessary write access. No step in the shown workflow requires broader token scopes.

Change location:
- File: `.github/workflows/fuzz-smoke.yml`
- Insert `permissions:` between the `on:` triggers and `env:` block (or anywhere top-level before `jobs:`).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
