### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 # Supersede in-flight runs when the same ref is pushed again; PR iteration
 # otherwise runs stale and current pipelines to completion side by side.
 concurrency:


### PR DESCRIPTION
Potential fix for [https://github.com/cadmpeg/cadmpeg/security/code-scanning/2](https://github.com/cadmpeg/cadmpeg/security/code-scanning/2)

Add an explicit top-level `permissions` block to `.github/workflows/ci.yml` so all jobs inherit least-privilege token access.

Best fix here: define workflow-level permissions as read-only for repository contents:
- `permissions:`
  - `contents: read`

Why this is best:
- All jobs in this workflow appear to only need source checkout and local commands.
- `actions/checkout` works with `contents: read`.
- A single root-level block avoids duplication and preserves existing behavior.

Where to change:
- File: `.github/workflows/ci.yml`
- Insert `permissions:` after the `on:` section (before `concurrency:` is a clean location), with `contents: read`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
