### PR TITLE
Agent ergonomics: scoped pre-commit gate, merge-stage restore, AGENTS.md operations guide

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -25,8 +25,31 @@ fi
 echo "pre-commit: cargo fmt --all --check"
 cargo fmt --all --check
 
-echo "pre-commit: cargo clippy --workspace -- -D warnings -W missing-docs"
-cargo clippy --workspace -- -D warnings -W missing-docs
+# Scope clippy and tests to the staged crates plus their transitive workspace
+# dependents. A leaf-codec commit must not fail on pre-existing lint debt in
+# crates it did not touch, and it must not pay full-workspace latency; a
+# shared-crate commit (cadmpeg-ir, cadmpeg-codec-core) still gates every
+# dependent codec through the reverse-dependency closure. Manifest, lockfile,
+# Cargo-config, and toolchain changes fall back to the full workspace, as does
+# any staged Rust file that no workspace crate owns.
+if git diff --cached --name-only \
+    | grep -qE '(^|/)Cargo\.(toml|lock)$|(^|/)rust-toolchain\.toml$|(^|/)\.cargo/'; then
+  scope="WORKSPACE"
+else
+  scope=$(python3 scripts/staged-crates.py)
+fi
 
-echo "pre-commit: cargo test-fast"
-cargo test-fast
+if [ "$scope" = "WORKSPACE" ]; then
+  echo "pre-commit: cargo clippy --workspace -- -D warnings -W missing-docs"
+  cargo clippy --workspace -- -D warnings -W missing-docs
+  echo "pre-commit: cargo test-fast"
+  cargo test-fast
+elif [ -n "$scope" ]; then
+  pkg_flags=$(printf ' -p %s' $scope)
+  echo "pre-commit: cargo clippy$pkg_flags -- -D warnings -W missing-docs"
+  cargo clippy $pkg_flags -- -D warnings -W missing-docs
+  echo "pre-commit: cargo test$pkg_flags --lib --bins --tests"
+  cargo test $pkg_flags --lib --bins --tests
+else
+  echo "pre-commit: staged Rust/Cargo files belong to no workspace crate; skipping"
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Multi-agent repository etiquette:
 
 Build and test operations:
 
-- Run several tests in one invocation: `cargo test name_a name_b`. Fast suite: `cargo test-fast`. Regenerate golden snapshots after an intended change: `UPDATE_GOLDEN=1 cargo test-fast golden`, then review the diff.
+- Run several tests in one invocation with filters after the separator: `cargo test -- name_a name_b`. Plain `cargo test name_a name_b` fails with `unexpected argument`. Fast suite: `cargo test-fast`. Regenerate golden snapshots after an intended change: `UPDATE_GOLDEN=1 cargo test-fast golden`, then review the diff.
 - The pre-commit gate scopes clippy and tests to the staged crates plus their workspace dependents. Triage a lint finding once and apply a targeted `#[allow]` with a comment; do not rerun the full gate against code you did not touch.
 - Changes to `cadmpeg-ir` or `cadmpeg-codec-core` fan out to every codec crate and diverge all goldens. Add struct fields through `Default` or constructor helpers and plan the fan-out before editing.
 - A successful decode is not a valid IR. Run `cadmpeg validate` on decoder output; it enforces ID-naming and topology conventions beyond decode success.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,23 @@
 - Do not treat finite evidence as an unknown. Do not put research history, project status, implementation bugs, or export behavior in specs.
 - When moving code, update callers to import from the owning module. Do not retain old paths through top-level or orchestration re-exports.
 - Commit early, commit often.
+
+Multi-agent repository etiquette:
+
+- One worktree and one branch per agent. Do not edit or build inside another agent's worktree.
+- Stage explicit paths only. Do not use `git add -A`, `git add .`, or `git commit -a`; they capture other agents' unstaged work.
+- Unstaged changes you did not make belong to another agent. Do not commit them, revert them, or bypass hooks because of them.
+- Use `--no-verify` only with the reason stated in the commit body.
+- In a conflicted merge, restore a file from a merge stage with `scripts/restore-merge-stage.sh`, not with `git checkout` or `git restore`.
+- When several agents build concurrently, isolate build artifacts: set a per-worktree `CARGO_TARGET_DIR`, or export `RUSTFLAGS="-C metadata=$(git branch --show-current)"` so a shared target directory stays collision-free.
+
+Build and test operations:
+
+- Run several tests in one invocation: `cargo test name_a name_b`. Fast suite: `cargo test-fast`. Regenerate golden snapshots after an intended change: `UPDATE_GOLDEN=1 cargo test-fast golden`, then review the diff.
+- The pre-commit gate scopes clippy and tests to the staged crates plus their workspace dependents. Triage a lint finding once and apply a targeted `#[allow]` with a comment; do not rerun the full gate against code you did not touch.
+- Changes to `cadmpeg-ir` or `cadmpeg-codec-core` fan out to every codec crate and diverge all goldens. Add struct fields through `Default` or constructor helpers and plan the fan-out before editing.
+- A successful decode is not a valid IR. Run `cadmpeg validate` on decoder output; it enforces ID-naming and topology conventions beyond decode success.
+- Test expectations come from the specification or approximate equality. Do not paste a failing run's observed output into an expectation.
+- Rebuild the `cadmpeg` binary before a batch decode run. An unchanged report after a code change indicates a stale binary, not an ineffective change.
+- Do not write file content back from a truncated read. Re-read a file after formatting hooks or context compaction before you patch it.
+- `/tmp` has a small quota. Put large scratch artifacts under `~/side2/tmp`.

--- a/scripts/restore-merge-stage.sh
+++ b/scripts/restore-merge-stage.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Restore conflicted files from a merge stage without `git checkout` or
+# `git restore`, which agent policy forbids. During a conflicted merge the
+# index holds three stages per path: 1 = base, 2 = ours, 3 = theirs. This
+# script writes the chosen stage's blob over the working-tree file and keeps
+# the previous working-tree content next to it as `<path>.premerge` so the
+# operation is additive and reversible.
+#
+# Usage:
+#   scripts/restore-merge-stage.sh --list
+#   scripts/restore-merge-stage.sh <base|ours|theirs|1|2|3> <path>...
+set -eu
+
+usage() {
+  echo "usage: $0 --list | <base|ours|theirs|1|2|3> <path>..." >&2
+  exit 2
+}
+
+[ $# -ge 1 ] || usage
+
+if [ "$1" = "--list" ]; then
+  git diff --name-only --diff-filter=U
+  exit 0
+fi
+
+case "$1" in
+  base|1) stage=1 ;;
+  ours|2) stage=2 ;;
+  theirs|3) stage=3 ;;
+  *) usage ;;
+esac
+shift
+[ $# -ge 1 ] || usage
+
+for path in "$@"; do
+  if ! git rev-parse --verify --quiet ":$stage:$path" >/dev/null; then
+    echo "$0: no stage $stage entry for '$path' (not conflicted, or wrong path)" >&2
+    exit 1
+  fi
+  if [ -f "$path" ]; then
+    cp -p "$path" "$path.premerge"
+  fi
+  git show ":$stage:$path" > "$path"
+  echo "restored '$path' from stage $stage (previous content: '$path.premerge')"
+done

--- a/scripts/staged-crates.py
+++ b/scripts/staged-crates.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Map staged files to the workspace crates the Rust gate must check.
+
+Reads the staged path list from `git diff --cached --name-only`, maps each
+path to the workspace crate that owns it (longest manifest-directory prefix),
+and expands the set with every workspace crate that depends on an affected
+crate, transitively. The pre-commit hook passes the result to
+`cargo clippy -p ...` and `cargo test -p ...` so a leaf-crate commit does not
+re-lint the whole workspace, while a change to a shared crate (for example
+`cadmpeg-ir`) still gates every dependent codec.
+
+Output: one crate name per line. Exit status 0 with the sentinel line
+`WORKSPACE` when scoping is not safe (a staged Rust file is outside every
+workspace crate). Empty output means no staged file belongs to any crate.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+
+def run(args: list[str]) -> str:
+    return subprocess.run(args, check=True, capture_output=True, text=True).stdout
+
+
+def main() -> int:
+    repo_root = run(["git", "rev-parse", "--show-toplevel"]).strip()
+    staged = [line for line in run(["git", "diff", "--cached", "--name-only"]).splitlines() if line]
+
+    meta = json.loads(run(["cargo", "metadata", "--no-deps", "--format-version", "1"]))
+    # Crate directory (repo-relative, no trailing slash) -> package name.
+    crate_dirs: dict[str, str] = {}
+    for pkg in meta["packages"]:
+        crate_dir = os.path.relpath(os.path.dirname(pkg["manifest_path"]), repo_root)
+        crate_dirs[crate_dir] = pkg["name"]
+
+    # Reverse dependencies among workspace members only.
+    names = set(crate_dirs.values())
+    rdeps: dict[str, set[str]] = {name: set() for name in names}
+    for pkg in meta["packages"]:
+        for dep in pkg["dependencies"]:
+            if dep["name"] in names:
+                rdeps[dep["name"]].add(pkg["name"])
+
+    affected: set[str] = set()
+    for path in staged:
+        owner = None
+        best = -1
+        for crate_dir, name in crate_dirs.items():
+            if (path.startswith(crate_dir + "/") or crate_dir == ".") and len(crate_dir) > best:
+                owner = name
+                best = len(crate_dir)
+        if owner is not None:
+            affected.add(owner)
+        elif path.endswith(".rs"):
+            # A Rust file outside every workspace crate: scoping is not safe.
+            print("WORKSPACE")
+            return 0
+
+    # Transitive closure over reverse dependencies.
+    frontier = list(affected)
+    while frontier:
+        for dependent in rdeps.get(frontier.pop(), ()):
+            if dependent not in affected:
+                affected.add(dependent)
+                frontier.append(dependent)
+
+    for name in sorted(affected):
+        print(name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements the non-delegated recommendations from the agent-trace analysis (~180 Codex/Claude sessions on this repo).

## Why
The costliest recurring failures were operational: full-workspace clippy reruns against untouched crates (188 reruns in one session, and the main driver of `--no-verify` bypasses), merge-stage recovery flailing under the `git checkout` ban, staged-work sweeps between concurrent agents, and per-session rediscovery of commands and conventions that compaction then erased.

## What
- **Scoped pre-commit Rust gate**: `scripts/staged-crates.py` maps staged paths to owning workspace crates and expands through the transitive reverse-dependency closure; the hook runs `clippy -p`/`test -p` on that set. Full-workspace fallback for manifest/lockfile/Cargo-config/toolchain changes and unowned Rust files. Verified: an iges-only stage scopes to `{cadmpeg-codec-iges, cadmpeg}` (clippy passes in 54s); a `cadmpeg-ir` stage fans out to all 11 dependents.
- **`scripts/restore-merge-stage.sh`**: sanctioned `--list` / `base|ours|theirs` restore via `git show :N:path`, additive (keeps `<path>.premerge`). Tested end-to-end on a synthetic conflicted merge including the error path.
- **AGENTS.md**: multi-agent git etiquette, per-branch build-artifact isolation, gate/test discipline (lint triage vs gate loops, shared-IR fan-out, `cadmpeg validate`, `UPDATE_GOLDEN=1 cargo test-fast golden`, stale-binary and truncated-read rules).

## Notes for review
- The scoped gate trades a small amount of pre-commit coverage (cross-crate breakage from non-dependency coupling, if any exists) for latency and thrash elimination; CI still runs the full gate.
- Not addressed here, flagged as follow-ups: splitting the oversized files (`resolved_features.rs` is 60k lines), a Fusion probe-file validator (needs an oracle), Codex-harness blocking exec.

Signed-off-by: pcurve <y7t7jvn2dr@privaterelay.appleid.com>
