### PR TITLE
Add byte-inspector subcommands under `cadmpeg inspect`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,13 +147,16 @@ dependencies = [
  "cadmpeg-codec-nx",
  "cadmpeg-codec-rhino",
  "cadmpeg-codec-sldprt",
+ "cadmpeg-container",
  "cadmpeg-ir",
  "cadmpeg-step",
  "clap",
  "crc32fast",
+ "memchr",
  "predicates",
  "serde_json",
  "tempfile",
+ "thiserror",
  "zip",
 ]
 

--- a/crates/cadmpeg/Cargo.toml
+++ b/crates/cadmpeg/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 cadmpeg-codec-core.workspace = true
+cadmpeg-container.workspace = true
 cadmpeg-ir.workspace = true
 cadmpeg-codec-f3d.workspace = true
 cadmpeg-codec-freecad.workspace = true
@@ -32,8 +33,10 @@ cadmpeg-codec-iges.workspace = true
 cadmpeg-step.workspace = true
 clap.workspace = true
 anyhow.workspace = true
+memchr.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/crates/cadmpeg/README.md
+++ b/crates/cadmpeg/README.md
@@ -86,6 +86,57 @@ cadmpeg export bracket.cadir.json -o bracket.step
 container diagnostics and normally requires `--allow-empty` when followed by a
 geometry export.
 
+## Read raw bytes
+
+`cadmpeg inspect` also carries byte tools that work on any file, decoded or not.
+They replace the ad-hoc `xxd`, `od`, `strings`, and `struct.unpack` one-liners
+that format work otherwise needs. Every offset and length argument accepts `0x`
+hexadecimal or decimal, and `_` between digits.
+
+```sh
+cadmpeg inspect hex part.prt --offset 0x40 --len 0x80   # dump with an ASCII gutter
+cadmpeg inspect read part.prt --type u32 --offset 0x40  # one scalar, decimal and hex
+cadmpeg inspect read part.prt --type f64 --offset 0x100 --count 8 --stride 24
+cadmpeg inspect find part.prt --hex '4d5a??00'          # `??` is a byte wildcard
+cadmpeg inspect find part.prt --utf16le Extrude
+cadmpeg inspect strings part.prt --min 6 --encoding both
+cadmpeg inspect struct part.prt --offset 0x100 --count 4 \
+  --layout 'u32le:id,pad4,f64le:x,f64le:y,f64le:z'
+cadmpeg inspect container part.f3d                      # ZIP entries with byte offsets
+cadmpeg inspect diff probe-a.prt probe-b.prt            # positional byte diff
+```
+
+`--le` and `--be` select the byte order for `read`; little-endian is the
+default. `read --count N` walks a record array, stepping `--stride` bytes and
+defaulting to the scalar width.
+
+`--layout` is a comma-separated record spec with no implicit alignment:
+
+| Field | Meaning |
+| --- | --- |
+| `u8`, `i8` | One byte. A byte-order suffix is rejected. |
+| `u16le`, `i32be`, `f64le`, … | A wide scalar. The `le` or `be` suffix is required. |
+| `bytesN` | `N` raw bytes, printed as hexadecimal. |
+| `padN` | `N` bytes skipped and not printed. Takes no name. |
+
+Every field except `padN` accepts an optional `:name`; unnamed fields are called
+`f<index>`. `struct --count N` decodes `N` consecutive records and reports an
+error rather than a partial record when the run passes end of file.
+
+`inspect container` lists ZIP entries with their local-header and payload
+offsets, so a hex dump of an entry follows directly. Names are single-quoted
+because Fusion `.f3d` entry names hold `[` and `]`, which a shell reads as a
+glob. Other container families are listed by `cadmpeg inspect FILE` through
+their codec.
+
+`inspect diff` compares byte `n` of one file with byte `n` of the other. It
+reports the first differing offset, the differing byte count, and the differing
+spans. `--gap` merges two spans separated by that many equal bytes or fewer.
+This is a byte comparison; `cadmpeg diff` compares decoded models instead.
+
+A file whose name is also a subcommand name, such as `hex`, is read as the
+subcommand. Write `./hex` for such a file.
+
 ## Compare models
 
 `diff` compares two decoded models structurally:

--- a/crates/cadmpeg/src/inspect/container.rs
+++ b/crates/cadmpeg/src/inspect/container.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+//! ZIP entry listing with the physical offsets the other byte tools take.
+
+use std::fmt::Write as _;
+
+use anyhow::{Context, Result};
+use cadmpeg_codec_core::decode::{DecodeArena, DecodeContext, DecodePolicy, ResourceLimits};
+use cadmpeg_container::{ArchiveSnapshot, EntryRecord};
+
+/// Lists the ZIP entries in `bytes`.
+///
+/// # Errors
+///
+/// Returns an error when the bytes exceed the resource-limit profile or the
+/// central directory does not parse.
+pub fn list(bytes: &[u8], limits: ResourceLimits) -> Result<Vec<EntryRecord>> {
+    let arena = DecodeArena::new();
+    let policy = DecodePolicy {
+        limits,
+        ..DecodePolicy::default()
+    };
+    let (_ctx, root) = DecodeContext::from_root_bytes(bytes, &arena, &policy)
+        .context("the file does not fit the resource-limit profile")?;
+    let snapshot = ArchiveSnapshot::new(root).context("reading the ZIP central directory")?;
+    Ok(snapshot.entries().to_vec())
+}
+
+/// Quotes an entry name so it survives a POSIX shell verbatim.
+///
+/// Fusion `.f3d` entry names hold `[` and `]`, which a shell expands as a glob
+/// character class. Single quotes suppress every expansion, and an embedded
+/// single quote is closed, escaped, and reopened.
+pub fn shell_quote(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 2);
+    out.push('\'');
+    for c in name.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+/// Formats an entry listing as an aligned table.
+pub fn render(entries: &[EntryRecord]) -> String {
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "{:>10}  {:>10}  {:>12}  {:>12}  {:>8}  {:>10}  name",
+        "header", "data", "packed", "unpacked", "method", "crc32"
+    );
+    for entry in entries {
+        let _ = writeln!(
+            out,
+            "0x{:08x}  0x{:08x}  {:>12}  {:>12}  {:>8}  0x{:08x}  {}",
+            entry.header_start,
+            entry.data_start,
+            entry.compressed_size,
+            entry.uncompressed_size,
+            entry.compression.label(),
+            entry.crc32,
+            shell_quote(&entry.name)
+        );
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quotes_plain_names() {
+        assert_eq!(shell_quote("Document.xml"), "'Document.xml'");
+    }
+
+    #[test]
+    fn quotes_bracketed_and_spaced_names() {
+        assert_eq!(
+            shell_quote("FusionAssetName[Active]/Design.dat"),
+            "'FusionAssetName[Active]/Design.dat'"
+        );
+        assert_eq!(shell_quote("a b"), "'a b'");
+        assert_eq!(shell_quote("$HOME`x`"), "'$HOME`x`'");
+    }
+
+    #[test]
+    fn closes_reopens_around_an_embedded_single_quote() {
+        // 'it'\''s' concatenates to the four characters it's in a POSIX shell.
+        assert_eq!(shell_quote("it's"), "'it'\\''s'");
+    }
+}

--- a/crates/cadmpeg/src/inspect/diff.rs
+++ b/crates/cadmpeg/src/inspect/diff.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Positional byte diff between two files.
+//!
+//! The comparison is positional, not an edit script: byte `n` of the first file
+//! is compared with byte `n` of the second. Probe variants of one exporter keep
+//! their field offsets, so a positional diff points straight at the changed
+//! fields. An inserted byte shifts everything after it and shows up as one long
+//! run, which is itself the signal that the files are not positional variants.
+
+/// A maximal span of differing bytes, after gap coalescing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DiffRun {
+    /// Offset of the first differing byte in the run.
+    pub start: u64,
+    /// Number of bytes the run covers, including coalesced equal bytes.
+    pub len: u64,
+}
+
+impl DiffRun {
+    /// Returns the exclusive end offset of the run.
+    pub const fn end(self) -> u64 {
+        self.start + self.len
+    }
+}
+
+/// A positional comparison of two byte strings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffSummary {
+    /// Length of the first input.
+    pub len_a: u64,
+    /// Length of the second input.
+    pub len_b: u64,
+    /// Number of bytes compared, that is the shorter of the two lengths.
+    pub compared: u64,
+    /// Count of differing bytes inside the compared prefix.
+    pub differing: u64,
+    /// Offset of the first differing byte, if any.
+    pub first: Option<u64>,
+    /// Differing spans after coalescing, in offset order.
+    pub runs: Vec<DiffRun>,
+}
+
+impl DiffSummary {
+    /// Returns true when the inputs are byte identical.
+    pub const fn identical(&self) -> bool {
+        self.len_a == self.len_b && self.differing == 0
+    }
+}
+
+/// Compares `a` and `b` positionally over their common prefix.
+///
+/// Two differing spans separated by `gap` or fewer equal bytes are reported as
+/// one run, so a changed multi-field record reads as a single region instead of
+/// one run per byte.
+pub fn compare(a: &[u8], b: &[u8], gap: u64) -> DiffSummary {
+    let compared = a.len().min(b.len());
+    let mut runs: Vec<DiffRun> = Vec::new();
+    let mut differing = 0u64;
+    for offset in 0..compared {
+        if a[offset] == b[offset] {
+            continue;
+        }
+        differing += 1;
+        let offset = offset as u64;
+        match runs.last_mut() {
+            Some(last) if offset <= last.end().saturating_add(gap) => {
+                last.len = offset - last.start + 1;
+            }
+            _ => runs.push(DiffRun {
+                start: offset,
+                len: 1,
+            }),
+        }
+    }
+    DiffSummary {
+        len_a: a.len() as u64,
+        len_b: b.len() as u64,
+        compared: compared as u64,
+        differing,
+        first: runs.first().map(|run| run.start),
+        runs,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_inputs_produce_no_runs() {
+        let summary = compare(b"abcd", b"abcd", 0);
+        assert!(summary.identical());
+        assert_eq!(summary.differing, 0);
+        assert_eq!(summary.first, None);
+        assert!(summary.runs.is_empty());
+    }
+
+    #[test]
+    fn a_length_difference_alone_is_not_identical() {
+        let summary = compare(b"abcd", b"abcdef", 0);
+        assert!(!summary.identical());
+        assert_eq!(summary.compared, 4);
+        assert_eq!(summary.differing, 0);
+        assert_eq!(summary.first, None);
+        assert_eq!((summary.len_a, summary.len_b), (4, 6));
+    }
+
+    #[test]
+    fn reports_the_first_difference_and_each_byte_at_gap_zero() {
+        // Differ at offsets 1 and 3 only.
+        let summary = compare(b"abcde", b"aXcYe", 0);
+        assert_eq!(summary.first, Some(1));
+        assert_eq!(summary.differing, 2);
+        assert_eq!(
+            summary.runs,
+            [DiffRun { start: 1, len: 1 }, DiffRun { start: 3, len: 1 },]
+        );
+    }
+
+    #[test]
+    fn coalesces_spans_separated_by_at_most_the_gap() {
+        // Differ at 1 and 3, so one equal byte lies between them.
+        let summary = compare(b"abcde", b"aXcYe", 1);
+        assert_eq!(summary.differing, 2);
+        assert_eq!(summary.runs, [DiffRun { start: 1, len: 3 }]);
+
+        // Differ at 0 and 4, so three equal bytes lie between them.
+        let wide = compare(b"abcde", b"XbcdY", 1);
+        assert_eq!(
+            wide.runs,
+            [DiffRun { start: 0, len: 1 }, DiffRun { start: 4, len: 1 },]
+        );
+        let merged = compare(b"abcde", b"XbcdY", 3);
+        assert_eq!(merged.runs, [DiffRun { start: 0, len: 5 }]);
+    }
+
+    #[test]
+    fn a_run_of_adjacent_differences_merges_at_any_gap() {
+        let summary = compare(&[0, 0, 0, 0], &[0, 1, 2, 3], 0);
+        assert_eq!(summary.runs, [DiffRun { start: 1, len: 3 }]);
+        assert_eq!(summary.differing, 3);
+    }
+
+    #[test]
+    fn only_the_common_prefix_is_compared() {
+        let summary = compare(b"abc", b"abcZZZZ", 0);
+        assert_eq!(summary.compared, 3);
+        assert_eq!(summary.differing, 0);
+        assert_eq!(summary.runs, []);
+    }
+
+    #[test]
+    fn empty_inputs_compare_cleanly() {
+        let summary = compare(&[], &[], 0);
+        assert!(summary.identical());
+        assert_eq!(summary.compared, 0);
+    }
+}

--- a/crates/cadmpeg/src/inspect/hexdump.rs
+++ b/crates/cadmpeg/src/inspect/hexdump.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Hexadecimal rendering with absolute file offsets and an ASCII gutter.
+
+use std::fmt::Write as _;
+
+/// Number of hexadecimal digits used for the offset column.
+///
+/// Eight digits address 4 GiB. Wider files widen the column so the layout stays
+/// aligned instead of ragged.
+fn offset_digits(last_offset: u64) -> usize {
+    let needed = format!("{last_offset:x}").len();
+    needed.max(8)
+}
+
+/// Renders `bytes` as a hexadecimal dump whose first byte sits at `base`.
+///
+/// Each line prints the absolute offset, `width` bytes in hexadecimal grouped in
+/// eights, and the printable ASCII for the same bytes between pipes. A short
+/// final line is padded so the gutter stays in one column.
+pub fn render(base: u64, bytes: &[u8], width: usize) -> String {
+    let width = width.max(1);
+    let last = base.saturating_add(bytes.len().saturating_sub(1) as u64);
+    let digits = offset_digits(last);
+    let mut out = String::new();
+    for (index, chunk) in bytes.chunks(width).enumerate() {
+        let offset = base.saturating_add((index * width) as u64);
+        let _ = write!(out, "{offset:0digits$x}  ");
+        for column in 0..width {
+            if column > 0 && column.is_multiple_of(8) {
+                out.push(' ');
+            }
+            match chunk.get(column) {
+                Some(byte) => {
+                    let _ = write!(out, "{byte:02x} ");
+                }
+                None => out.push_str("   "),
+            }
+        }
+        out.push_str(" |");
+        for byte in chunk {
+            out.push(printable(*byte));
+        }
+        out.push('|');
+        out.push('\n');
+    }
+    out
+}
+
+/// Maps one byte to its ASCII gutter character.
+const fn printable(byte: u8) -> char {
+    if byte.is_ascii_graphic() || byte == b' ' {
+        byte as char
+    } else {
+        '.'
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_one_full_line_with_grouping_and_gutter() {
+        let bytes: Vec<u8> = (0x40u8..0x50).collect();
+        let text = render(0, &bytes, 16);
+        assert_eq!(
+            text,
+            "00000000  40 41 42 43 44 45 46 47  48 49 4a 4b 4c 4d 4e 4f  |@ABCDEFGHIJKLMNO|\n"
+        );
+    }
+
+    #[test]
+    fn pads_a_short_final_line_so_the_gutter_stays_aligned() {
+        let text = render(0x10, b"hi", 16);
+        let line = text.trim_end_matches('\n');
+        let full = render(0x10, &[0u8; 16], 16);
+        let full_line = full.trim_end_matches('\n');
+        assert_eq!(
+            line.find('|').unwrap(),
+            full_line.find('|').unwrap(),
+            "gutter column must not move"
+        );
+        assert!(line.ends_with("|hi|"), "got {line}");
+        assert!(line.starts_with("00000010  68 69 "), "got {line}");
+    }
+
+    #[test]
+    fn non_printable_bytes_become_dots_and_space_stays_a_space() {
+        let text = render(0, &[0x00, 0x20, 0x7e, 0x7f, 0xff], 8);
+        assert!(text.ends_with("|. ~..|\n"), "got {text}");
+    }
+
+    #[test]
+    fn offsets_are_absolute_and_widen_past_four_gibibytes() {
+        let text = render(0x1_0000_0000, &[0u8; 1], 16);
+        assert!(text.starts_with("100000000  00 "), "got {text}");
+        let narrow = render(0xff, &[0u8; 1], 16);
+        assert!(narrow.starts_with("000000ff  00 "), "got {narrow}");
+    }
+
+    #[test]
+    fn respects_a_custom_width() {
+        let text = render(0, &[1, 2, 3, 4, 5], 2);
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].starts_with("00000000  01 02 "));
+        assert!(lines[1].starts_with("00000002  03 04 "));
+        assert!(lines[2].starts_with("00000004  05 "));
+    }
+}

--- a/crates/cadmpeg/src/inspect/layout.rs
+++ b/crates/cadmpeg/src/inspect/layout.rs
@@ -1,0 +1,547 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The `--layout` record mini-language.
+//!
+//! A layout is a comma-separated list of fields read back to back with no
+//! implicit alignment or padding. Each field is one of:
+//!
+//! - `u8`, `i8` — one byte, no byte-order suffix is allowed.
+//! - `u16le`, `i32be`, `f64le`, … — a wide scalar; the `le` or `be` suffix is
+//!   mandatory.
+//! - `bytesN` — `N` raw bytes, printed as hexadecimal.
+//! - `padN` — `N` bytes skipped and not printed. Takes no name.
+//!
+//! Every field except `padN` accepts an optional `:name`. Unnamed fields are
+//! called `f<index>` after their position in the spec.
+//!
+//! Example: `u32le:count,pad4,f64le:x,f64le:y,bytes4:tag`.
+
+use std::fmt::Write as _;
+
+use super::numeric::{Endian, ScalarType};
+
+/// A parse failure in a layout spec.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum LayoutError {
+    /// The whole spec was empty or whitespace.
+    #[error("empty layout; expected fields such as `u32le:count,f64le:x`")]
+    EmptySpec,
+    /// A comma-separated token was empty.
+    #[error("layout field {index} is empty; remove the stray comma")]
+    EmptyField {
+        /// Zero-based position of the token in the spec.
+        index: usize,
+    },
+    /// A token ended in `:` with no name after it.
+    #[error("layout field {index} (`{token}`) has a `:` with no name after it")]
+    EmptyName {
+        /// Zero-based position of the token in the spec.
+        index: usize,
+        /// The offending token.
+        token: String,
+    },
+    /// A field name held a second `:`.
+    #[error("`{token}`: a field name cannot contain `:`")]
+    NameHasColon {
+        /// The offending token.
+        token: String,
+    },
+    /// A wide scalar was written without an `le` or `be` suffix.
+    #[error("`{token}`: `{base}` needs a byte-order suffix, as in `{base}le` or `{base}be`")]
+    MissingByteOrder {
+        /// The offending token.
+        token: String,
+        /// The scalar base name.
+        base: String,
+    },
+    /// A one-byte scalar carried a byte-order suffix.
+    #[error("`{token}`: `{base}` is one byte wide, so it takes no `{suffix}` suffix")]
+    ForbiddenByteOrder {
+        /// The offending token.
+        token: String,
+        /// The scalar base name.
+        base: String,
+        /// The rejected suffix.
+        suffix: &'static str,
+    },
+    /// The type name matched nothing in the grammar.
+    #[error(
+        "`{token}`: unknown field type `{type_text}`; expected u8/i8, \
+         u16/i16/u32/i32/u64/i64/f32/f64 with an `le` or `be` suffix, `bytesN`, or `padN`"
+    )]
+    UnknownType {
+        /// The offending token.
+        token: String,
+        /// The unrecognised type text.
+        type_text: String,
+    },
+    /// `bytes` or `pad` appeared with no byte count.
+    #[error("`{token}`: `{keyword}` needs a byte count, as in `{keyword}4`")]
+    MissingCount {
+        /// The offending token.
+        token: String,
+        /// The keyword that needs a count.
+        keyword: &'static str,
+    },
+    /// The byte count after `bytes` or `pad` was not a decimal number.
+    #[error("`{token}`: `{digits}` is not a decimal byte count for `{keyword}`")]
+    BadCount {
+        /// The offending token.
+        token: String,
+        /// The keyword that needs a count.
+        keyword: &'static str,
+        /// The text that failed to parse.
+        digits: String,
+    },
+    /// The byte count after `bytes` or `pad` was zero.
+    #[error("`{token}`: a `{keyword}` field must cover at least one byte")]
+    ZeroCount {
+        /// The offending token.
+        token: String,
+        /// The keyword that needs a count.
+        keyword: &'static str,
+    },
+    /// A `padN` field carried a name.
+    #[error("`{token}`: a pad field is never printed, so it takes no name")]
+    NamedPad {
+        /// The offending token.
+        token: String,
+    },
+    /// The accumulated record size overflowed a machine word.
+    #[error("`{token}`: record size overflows a machine word")]
+    SizeOverflow {
+        /// The offending token.
+        token: String,
+    },
+}
+
+/// What one layout field reads out of the record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldKind {
+    /// A fixed-width number in a stated byte order.
+    Scalar(ScalarType, Endian),
+    /// A run of raw bytes rendered as hexadecimal.
+    Bytes(usize),
+    /// A run of bytes that is skipped and never printed.
+    Pad(usize),
+}
+
+impl FieldKind {
+    /// Returns how many bytes the field consumes.
+    pub const fn width(self) -> usize {
+        match self {
+            Self::Scalar(ty, _) => ty.width(),
+            Self::Bytes(count) | Self::Pad(count) => count,
+        }
+    }
+
+    /// Returns the type name as it appears in a decoded record listing.
+    pub fn type_name(self) -> String {
+        match self {
+            Self::Scalar(ty, endian) => ty.display_name(endian),
+            Self::Bytes(count) => format!("bytes{count}"),
+            Self::Pad(count) => format!("pad{count}"),
+        }
+    }
+}
+
+/// One named field and its byte offset inside the record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Field {
+    /// Field name, defaulted to `f<index>` when the spec omits one.
+    pub name: String,
+    /// What the field reads.
+    pub kind: FieldKind,
+    /// Byte offset of the field from the start of the record.
+    pub offset: usize,
+}
+
+/// A parsed record layout.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Layout {
+    /// Fields in spec order, including `padN` runs.
+    pub fields: Vec<Field>,
+    /// Total record size in bytes.
+    pub size: usize,
+}
+
+impl Layout {
+    /// Parses a layout spec.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LayoutError`] for an empty spec, an empty or unknown field
+    /// token, a missing or forbidden byte-order suffix, a zero or unparsable
+    /// `bytesN`/`padN` count, a name on a `padN` field, or a record whose total
+    /// size overflows `usize`.
+    pub fn parse(spec: &str) -> Result<Self, LayoutError> {
+        if spec.trim().is_empty() {
+            return Err(LayoutError::EmptySpec);
+        }
+        let mut fields = Vec::new();
+        let mut offset: usize = 0;
+        for (index, raw_token) in spec.split(',').enumerate() {
+            let token = raw_token.trim();
+            if token.is_empty() {
+                return Err(LayoutError::EmptyField { index });
+            }
+            let (type_text, name) = split_name(token, index)?;
+            let kind = parse_kind(type_text, token)?;
+            if matches!(kind, FieldKind::Pad(_)) && name.is_some() {
+                return Err(LayoutError::NamedPad {
+                    token: token.to_string(),
+                });
+            }
+            let name = name.unwrap_or_else(|| format!("f{index}"));
+            fields.push(Field { name, kind, offset });
+            offset = offset
+                .checked_add(kind.width())
+                .ok_or_else(|| LayoutError::SizeOverflow {
+                    token: token.to_string(),
+                })?;
+        }
+        Ok(Self {
+            fields,
+            size: offset,
+        })
+    }
+
+    /// Decodes one record from a slice of exactly [`Layout::size`] bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `record` is not exactly the record size. Callers bounds-check
+    /// against the file length before slicing.
+    pub fn decode(&self, record: &[u8]) -> Vec<DecodedField> {
+        assert_eq!(
+            record.len(),
+            self.size,
+            "record slice must match the layout"
+        );
+        self.fields
+            .iter()
+            .filter(|field| !matches!(field.kind, FieldKind::Pad(_)))
+            .map(|field| {
+                let bytes = &record[field.offset..field.offset + field.kind.width()];
+                let (decimal, hex) = match field.kind {
+                    FieldKind::Scalar(ty, endian) => {
+                        let value = ty.read(bytes, endian);
+                        (value.decimal(), value.hex(ty))
+                    }
+                    FieldKind::Bytes(_) => (String::new(), hex_bytes(bytes)),
+                    FieldKind::Pad(_) => unreachable!("pad fields are filtered out"),
+                };
+                DecodedField {
+                    name: field.name.clone(),
+                    type_name: field.kind.type_name(),
+                    offset: field.offset,
+                    decimal,
+                    hex,
+                }
+            })
+            .collect()
+    }
+}
+
+/// One field of a decoded record, ready to print.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedField {
+    /// Field name.
+    pub name: String,
+    /// Type name including any byte-order suffix.
+    pub type_name: String,
+    /// Byte offset from the start of the record.
+    pub offset: usize,
+    /// Decimal rendering, empty for `bytesN` fields.
+    pub decimal: String,
+    /// Hexadecimal rendering of the encoded bytes.
+    pub hex: String,
+}
+
+fn split_name(token: &str, index: usize) -> Result<(&str, Option<String>), LayoutError> {
+    match token.split_once(':') {
+        None => Ok((token, None)),
+        Some((type_text, name)) => {
+            let name = name.trim();
+            if name.is_empty() {
+                return Err(LayoutError::EmptyName {
+                    index,
+                    token: token.to_string(),
+                });
+            }
+            if name.contains(':') {
+                return Err(LayoutError::NameHasColon {
+                    token: token.to_string(),
+                });
+            }
+            Ok((type_text.trim(), Some(name.to_string())))
+        }
+    }
+}
+
+fn parse_kind(type_text: &str, token: &str) -> Result<FieldKind, LayoutError> {
+    if let Some(count) = type_text.strip_prefix("bytes") {
+        return parse_count(count, token, "bytes").map(FieldKind::Bytes);
+    }
+    if let Some(count) = type_text.strip_prefix("pad") {
+        return parse_count(count, token, "pad").map(FieldKind::Pad);
+    }
+    if let Some(ty) = ScalarType::from_base_name(type_text) {
+        if ty.is_single_byte() {
+            return Ok(FieldKind::Scalar(ty, Endian::Little));
+        }
+        return Err(LayoutError::MissingByteOrder {
+            token: token.to_string(),
+            base: type_text.to_string(),
+        });
+    }
+    for (suffix, endian) in [("le", Endian::Little), ("be", Endian::Big)] {
+        let Some(base) = type_text.strip_suffix(suffix) else {
+            continue;
+        };
+        let Some(ty) = ScalarType::from_base_name(base) else {
+            continue;
+        };
+        if ty.is_single_byte() {
+            return Err(LayoutError::ForbiddenByteOrder {
+                token: token.to_string(),
+                base: base.to_string(),
+                suffix,
+            });
+        }
+        return Ok(FieldKind::Scalar(ty, endian));
+    }
+    Err(LayoutError::UnknownType {
+        token: token.to_string(),
+        type_text: type_text.to_string(),
+    })
+}
+
+fn parse_count(digits: &str, token: &str, keyword: &'static str) -> Result<usize, LayoutError> {
+    if digits.is_empty() {
+        return Err(LayoutError::MissingCount {
+            token: token.to_string(),
+            keyword,
+        });
+    }
+    let count: usize = digits.parse().map_err(|_| LayoutError::BadCount {
+        token: token.to_string(),
+        keyword,
+        digits: digits.to_string(),
+    })?;
+    if count == 0 {
+        return Err(LayoutError::ZeroCount {
+            token: token.to_string(),
+            keyword,
+        });
+    }
+    Ok(count)
+}
+
+fn hex_bytes(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 3);
+    for (index, byte) in bytes.iter().enumerate() {
+        if index > 0 {
+            out.push(' ');
+        }
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kinds(spec: &str) -> Vec<FieldKind> {
+        Layout::parse(spec)
+            .unwrap()
+            .fields
+            .into_iter()
+            .map(|field| field.kind)
+            .collect()
+    }
+
+    #[test]
+    fn parses_the_documented_example() {
+        let layout = Layout::parse("u32le:count,pad4,f64le:x,f64le:y,bytes4:tag").unwrap();
+        assert_eq!(layout.size, 4 + 4 + 8 + 8 + 4);
+        let names: Vec<&str> = layout
+            .fields
+            .iter()
+            .map(|field| field.name.as_str())
+            .collect();
+        assert_eq!(names, ["count", "f1", "x", "y", "tag"]);
+        let offsets: Vec<usize> = layout.fields.iter().map(|field| field.offset).collect();
+        assert_eq!(offsets, [0, 4, 8, 16, 24]);
+    }
+
+    #[test]
+    fn accepts_every_scalar_width_and_both_byte_orders() {
+        assert_eq!(
+            kinds("u8,i8"),
+            [
+                FieldKind::Scalar(ScalarType::U8, Endian::Little),
+                FieldKind::Scalar(ScalarType::I8, Endian::Little),
+            ]
+        );
+        assert_eq!(
+            kinds("u16be,i64le,f32be,f64le"),
+            [
+                FieldKind::Scalar(ScalarType::U16, Endian::Big),
+                FieldKind::Scalar(ScalarType::I64, Endian::Little),
+                FieldKind::Scalar(ScalarType::F32, Endian::Big),
+                FieldKind::Scalar(ScalarType::F64, Endian::Little),
+            ]
+        );
+    }
+
+    #[test]
+    fn tolerates_whitespace_around_tokens_and_names() {
+        let layout = Layout::parse(" u32le : count , f64be:x ").unwrap();
+        assert_eq!(layout.size, 12);
+        assert_eq!(layout.fields[0].name, "count");
+        assert_eq!(layout.fields[1].name, "x");
+    }
+
+    #[track_caller]
+    fn error(spec: &str) -> LayoutError {
+        Layout::parse(spec).expect_err("spec should not parse")
+    }
+
+    #[test]
+    fn rejects_empty_specs_and_stray_commas() {
+        assert_eq!(error(""), LayoutError::EmptySpec);
+        assert_eq!(error("   "), LayoutError::EmptySpec);
+        assert_eq!(error(","), LayoutError::EmptyField { index: 0 });
+        assert_eq!(error(",u32le"), LayoutError::EmptyField { index: 0 });
+        assert_eq!(error("u32le,"), LayoutError::EmptyField { index: 1 });
+        assert_eq!(error("u32le,,f64le"), LayoutError::EmptyField { index: 1 });
+    }
+
+    #[test]
+    fn rejects_a_colon_with_no_name() {
+        assert_eq!(
+            error("u32le:"),
+            LayoutError::EmptyName {
+                index: 0,
+                token: "u32le:".to_string(),
+            }
+        );
+        assert_eq!(
+            error("f64le,u32le: "),
+            LayoutError::EmptyName {
+                index: 1,
+                token: "u32le:".to_string(),
+            }
+        );
+        assert_eq!(
+            error("u32le:a:b"),
+            LayoutError::NameHasColon {
+                token: "u32le:a:b".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_missing_or_forbidden_byte_order_suffixes() {
+        assert_eq!(
+            error("u32"),
+            LayoutError::MissingByteOrder {
+                token: "u32".to_string(),
+                base: "u32".to_string(),
+            }
+        );
+        assert_eq!(
+            error("u8le"),
+            LayoutError::ForbiddenByteOrder {
+                token: "u8le".to_string(),
+                base: "u8".to_string(),
+                suffix: "le",
+            }
+        );
+        assert_eq!(
+            error("i8be"),
+            LayoutError::ForbiddenByteOrder {
+                token: "i8be".to_string(),
+                base: "i8".to_string(),
+                suffix: "be",
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_types() {
+        for bad in ["u24le", "float64", "u32me"] {
+            assert!(
+                matches!(error(bad), LayoutError::UnknownType { .. }),
+                "{bad:?} should be an unknown type, got {:?}",
+                error(bad)
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_bad_bytes_and_pad_counts() {
+        assert_eq!(
+            error("bytes"),
+            LayoutError::MissingCount {
+                token: "bytes".to_string(),
+                keyword: "bytes",
+            }
+        );
+        assert_eq!(
+            error("bytes0"),
+            LayoutError::ZeroCount {
+                token: "bytes0".to_string(),
+                keyword: "bytes",
+            }
+        );
+        assert_eq!(
+            error("pad0"),
+            LayoutError::ZeroCount {
+                token: "pad0".to_string(),
+                keyword: "pad",
+            }
+        );
+        assert_eq!(
+            error("padx"),
+            LayoutError::BadCount {
+                token: "padx".to_string(),
+                keyword: "pad",
+                digits: "x".to_string(),
+            }
+        );
+        assert!(matches!(error("bytes-1"), LayoutError::BadCount { .. }));
+    }
+
+    #[test]
+    fn rejects_a_named_pad() {
+        assert_eq!(
+            error("pad4:reserved"),
+            LayoutError::NamedPad {
+                token: "pad4:reserved".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn decode_reads_hand_built_bytes_and_drops_pad() {
+        let layout = Layout::parse("u32le:count,pad2,i16be:delta,bytes2:tag").unwrap();
+        assert_eq!(layout.size, 10);
+        // count = 0x0000002a = 42, pad, delta = 0xfffe = -2, tag = ab cd.
+        let record = [0x2a, 0x00, 0x00, 0x00, 0xee, 0xee, 0xff, 0xfe, 0xab, 0xcd];
+        let decoded = layout.decode(&record);
+        assert_eq!(decoded.len(), 3);
+        assert_eq!(decoded[0].name, "count");
+        assert_eq!(decoded[0].type_name, "u32le");
+        assert_eq!(decoded[0].decimal, "42");
+        assert_eq!(decoded[0].hex, "0x0000002a");
+        assert_eq!(decoded[1].name, "delta");
+        assert_eq!(decoded[1].decimal, "-2");
+        assert_eq!(decoded[1].hex, "0xfffe");
+        assert_eq!(decoded[1].offset, 6);
+        assert_eq!(decoded[2].type_name, "bytes2");
+        assert_eq!(decoded[2].hex, "ab cd");
+        assert_eq!(decoded[2].decimal, "");
+    }
+}

--- a/crates/cadmpeg/src/inspect/mod.rs
+++ b/crates/cadmpeg/src/inspect/mod.rs
@@ -249,9 +249,9 @@ fn read(args: &ReadArgs) -> Result<()> {
     let mut file =
         File::open(&args.file).with_context(|| format!("opening {}", args.file.display()))?;
     for index in 0..args.count {
-        let offset = args
-            .offset
-            .checked_add(index * stride)
+        let offset = index
+            .checked_mul(stride)
+            .and_then(|step| args.offset.checked_add(step))
             .context("the strided offset overflows 64 bits")?;
         let end = offset
             .checked_add(width)
@@ -284,7 +284,7 @@ fn find(args: &FindArgs) -> Result<()> {
     } else if let Some(text) = &args.utf16le {
         (search::utf16le_pattern(text), format!("utf16le {text:?}"))
     } else {
-        unreachable!("clap requires one of --hex, --ascii, or --utf16le")
+        bail!("pass one of --hex, --ascii, or --utf16le")
     };
     let pattern = pattern.map_err(|message| anyhow::anyhow!(message))?;
     let bytes = read_whole(&args.file)?;
@@ -369,7 +369,7 @@ fn container_list(args: &ContainerArgs) -> Result<()> {
     let bytes = read_whole(&args.file)?;
     let entries = container::list(&bytes, args.limits.limits()).with_context(|| {
         format!(
-            "{} is not a readable ZIP container; `cadmpeg inspect {}` reads \
+            "cannot list {} as a ZIP container; `cadmpeg inspect {}` reads \
              the other container families through their codec",
             args.file.display(),
             args.file.display()

--- a/crates/cadmpeg/src/inspect/mod.rs
+++ b/crates/cadmpeg/src/inspect/mod.rs
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Format-agnostic byte tools under `cadmpeg inspect`.
+//!
+//! These subcommands read a file as bytes. They know nothing about CAD formats,
+//! so they work on a container, on an entry extracted from one, and on a probe
+//! variant that no codec accepts yet. `cadmpeg inspect FILE` without a
+//! subcommand still runs the codec-aware container summary.
+//!
+//! Every offset and length argument accepts hexadecimal with an `0x` prefix or
+//! decimal, with `_` allowed between digits.
+
+pub mod container;
+pub mod diff;
+pub mod hexdump;
+pub mod layout;
+pub mod numeric;
+pub mod search;
+
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use clap::{Args, Subcommand};
+
+use crate::LimitProfile;
+use numeric::{parse_offset, EndianArgs, ScalarType};
+
+/// Default number of bytes a bare `inspect hex` prints.
+const DEFAULT_HEX_LEN: u64 = 256;
+
+/// Byte-level subcommands of `cadmpeg inspect`.
+#[derive(Debug, Subcommand)]
+pub enum ByteCommand {
+    /// Print a hexadecimal dump with absolute offsets and an ASCII gutter.
+    Hex(HexArgs),
+    /// Read fixed-width scalars at an offset, optionally striding a record array.
+    Read(ReadArgs),
+    /// Report every offset where a byte pattern or a text string occurs.
+    Find(FindArgs),
+    /// Extract printable strings.
+    Strings(StringsArgs),
+    /// Decode records with an inline `--layout` spec.
+    Struct(StructArgs),
+    /// List ZIP entries with their physical offsets.
+    Container(ContainerArgs),
+    /// Compare two files byte for byte at the same offsets.
+    Diff(DiffArgs),
+}
+
+/// Arguments for `cadmpeg inspect hex`.
+#[derive(Debug, Args)]
+pub struct HexArgs {
+    /// File to dump.
+    pub file: PathBuf,
+    /// First byte to print.
+    #[arg(long, default_value = "0", value_parser = parse_offset)]
+    pub offset: u64,
+    /// Number of bytes to print; the dump stops early at end of file.
+    #[arg(long, value_parser = parse_offset)]
+    pub len: Option<u64>,
+    /// Bytes per output line.
+    #[arg(long, default_value_t = 16)]
+    pub width: usize,
+}
+
+/// Arguments for `cadmpeg inspect read`.
+#[derive(Debug, Args)]
+pub struct ReadArgs {
+    /// File to read.
+    pub file: PathBuf,
+    /// Scalar type to decode.
+    #[arg(long = "type", value_enum)]
+    pub ty: ScalarType,
+    /// Offset of the first value.
+    #[arg(long, default_value = "0", value_parser = parse_offset)]
+    pub offset: u64,
+    /// How many values to read.
+    #[arg(long, default_value_t = 1)]
+    pub count: u64,
+    /// Byte step between consecutive values; defaults to the scalar width.
+    #[arg(long, value_parser = parse_offset)]
+    pub stride: Option<u64>,
+    #[command(flatten)]
+    pub endian: EndianArgs,
+}
+
+/// Arguments for `cadmpeg inspect find`.
+#[derive(Debug, Args)]
+#[command(group(clap::ArgGroup::new("needle").required(true).args(["hex", "ascii", "utf16le"])))]
+pub struct FindArgs {
+    /// File to search.
+    pub file: PathBuf,
+    /// Hexadecimal byte pattern; `??` matches any byte.
+    #[arg(long)]
+    pub hex: Option<String>,
+    /// ASCII string to search for.
+    #[arg(long)]
+    pub ascii: Option<String>,
+    /// String to search for encoded as UTF-16LE.
+    #[arg(long)]
+    pub utf16le: Option<String>,
+    /// Stop after this many hits; 0 reports every hit.
+    #[arg(long, default_value_t = 100)]
+    pub max: usize,
+}
+
+/// Arguments for `cadmpeg inspect strings`.
+#[derive(Debug, Args)]
+pub struct StringsArgs {
+    /// File to scan.
+    pub file: PathBuf,
+    /// Shortest run to report, in characters.
+    #[arg(long, default_value_t = 4)]
+    pub min: usize,
+    /// Which encodings to scan for.
+    #[arg(long, value_enum, default_value_t = search::StringEncoding::Ascii)]
+    pub encoding: search::StringEncoding,
+}
+
+/// Arguments for `cadmpeg inspect struct`.
+#[derive(Debug, Args)]
+pub struct StructArgs {
+    /// File to decode.
+    pub file: PathBuf,
+    /// Record layout, for example `u32le:count,pad4,f64le:x,f64le:y`.
+    #[arg(long)]
+    pub layout: String,
+    /// Offset of the first record.
+    #[arg(long, default_value = "0", value_parser = parse_offset)]
+    pub offset: u64,
+    /// How many consecutive records to decode.
+    #[arg(long, default_value_t = 1)]
+    pub count: u64,
+}
+
+/// Arguments for `cadmpeg inspect container`.
+#[derive(Debug, Args)]
+pub struct ContainerArgs {
+    /// ZIP-based file to list.
+    pub file: PathBuf,
+    /// Resource-limit profile applied while reading the central directory.
+    #[arg(long, value_enum, default_value_t = LimitProfile::Desktop)]
+    pub limits: LimitProfile,
+}
+
+/// Arguments for `cadmpeg inspect diff`.
+#[derive(Debug, Args)]
+pub struct DiffArgs {
+    /// First file.
+    pub a: PathBuf,
+    /// Second file.
+    pub b: PathBuf,
+    /// Merge two differing spans separated by this many equal bytes or fewer.
+    #[arg(long, default_value_t = 8)]
+    pub gap: u64,
+    /// Stop listing after this many runs; 0 lists every run.
+    #[arg(long, default_value_t = 32)]
+    pub max_runs: usize,
+    /// Bytes of context dumped on each side of the first difference.
+    #[arg(long, default_value = "32", value_parser = parse_offset)]
+    pub context: u64,
+}
+
+/// Runs one byte subcommand.
+///
+/// # Errors
+///
+/// Returns an operational error when a file cannot be read, an argument does
+/// not parse, or a requested offset lies past end of file.
+pub fn run(command: ByteCommand) -> Result<()> {
+    match command {
+        ByteCommand::Hex(args) => hex(&args),
+        ByteCommand::Read(args) => read(&args),
+        ByteCommand::Find(args) => find(&args),
+        ByteCommand::Strings(args) => strings(&args),
+        ByteCommand::Struct(args) => structure(&args),
+        ByteCommand::Container(args) => container_list(&args),
+        ByteCommand::Diff(args) => diff_files(&args),
+    }
+}
+
+/// Returns the file length in bytes.
+fn file_len(path: &Path) -> Result<u64> {
+    let metadata = std::fs::metadata(path)
+        .with_context(|| format!("reading metadata for {}", path.display()))?;
+    Ok(metadata.len())
+}
+
+/// Reads up to `len` bytes starting at `offset`, returning fewer at end of file.
+///
+/// Seeking past end of file is an error rather than an empty result, because an
+/// offset outside the file is always a mistake worth reporting.
+fn read_window(path: &Path, offset: u64, len: u64) -> Result<Vec<u8>> {
+    let size = file_len(path)?;
+    if offset > size {
+        bail!(
+            "offset 0x{offset:x} ({offset}) is past the end of {}, which is 0x{size:x} ({size}) bytes",
+            path.display()
+        );
+    }
+    let available = size - offset;
+    let want = usize::try_from(len.min(available))
+        .context("the requested length does not fit in memory on this target")?;
+    let mut file = File::open(path).with_context(|| format!("opening {}", path.display()))?;
+    file.seek(SeekFrom::Start(offset))
+        .with_context(|| format!("seeking to 0x{offset:x} in {}", path.display()))?;
+    let mut buffer = vec![0u8; want];
+    file.read_exact(&mut buffer).with_context(|| {
+        format!(
+            "reading {want} bytes at 0x{offset:x} from {}",
+            path.display()
+        )
+    })?;
+    Ok(buffer)
+}
+
+/// Reads a whole file.
+fn read_whole(path: &Path) -> Result<Vec<u8>> {
+    std::fs::read(path).with_context(|| format!("reading {}", path.display()))
+}
+
+fn hex(args: &HexArgs) -> Result<()> {
+    if args.width == 0 {
+        bail!("--width must be at least 1");
+    }
+    let len = args.len.unwrap_or(DEFAULT_HEX_LEN);
+    let bytes = read_window(&args.file, args.offset, len)?;
+    if bytes.is_empty() {
+        println!("(no bytes at 0x{:x})", args.offset);
+        return Ok(());
+    }
+    print!("{}", hexdump::render(args.offset, &bytes, args.width));
+    Ok(())
+}
+
+fn read(args: &ReadArgs) -> Result<()> {
+    let width = args.ty.width() as u64;
+    let stride = args.stride.unwrap_or(width);
+    if args.count == 0 {
+        return Ok(());
+    }
+    if stride == 0 {
+        bail!("--stride 0 would read the same bytes forever");
+    }
+    let endian = args.endian.endian();
+    let size = file_len(&args.file)?;
+    let name = args.ty.display_name(endian);
+    let mut file =
+        File::open(&args.file).with_context(|| format!("opening {}", args.file.display()))?;
+    for index in 0..args.count {
+        let offset = args
+            .offset
+            .checked_add(index * stride)
+            .context("the strided offset overflows 64 bits")?;
+        let end = offset
+            .checked_add(width)
+            .context("the read overflows 64 bits")?;
+        if end > size {
+            bail!(
+                "value {index} needs bytes 0x{offset:x}..0x{end:x}, past the end of {} at 0x{size:x}",
+                args.file.display()
+            );
+        }
+        file.seek(SeekFrom::Start(offset))?;
+        let mut buffer = [0u8; 8];
+        let slot = &mut buffer[..width as usize];
+        file.read_exact(slot)?;
+        let value = args.ty.read(slot, endian);
+        println!(
+            "0x{offset:08x}  {name:<6}  {:<24}  {}",
+            value.decimal(),
+            value.hex(args.ty)
+        );
+    }
+    Ok(())
+}
+
+fn find(args: &FindArgs) -> Result<()> {
+    let (pattern, described) = if let Some(text) = &args.hex {
+        (search::parse_pattern(text), format!("hex {text}"))
+    } else if let Some(text) = &args.ascii {
+        (search::ascii_pattern(text), format!("ascii {text:?}"))
+    } else if let Some(text) = &args.utf16le {
+        (search::utf16le_pattern(text), format!("utf16le {text:?}"))
+    } else {
+        unreachable!("clap requires one of --hex, --ascii, or --utf16le")
+    };
+    let pattern = pattern.map_err(|message| anyhow::anyhow!(message))?;
+    let bytes = read_whole(&args.file)?;
+    let limit = (args.max > 0).then_some(args.max);
+    let hits = search::find_all(&bytes, &pattern, limit);
+    println!(
+        "pattern: {described} ({} bytes)  hits: {}{}",
+        pattern.len(),
+        hits.len(),
+        if limit.is_some_and(|max| hits.len() >= max) {
+            " (truncated by --max)"
+        } else {
+            ""
+        }
+    );
+    for offset in hits {
+        println!("0x{offset:08x}  {offset}");
+    }
+    Ok(())
+}
+
+fn strings(args: &StringsArgs) -> Result<()> {
+    if args.min == 0 {
+        bail!("--min must be at least 1");
+    }
+    let bytes = read_whole(&args.file)?;
+    for found in search::extract_strings(&bytes, args.min, args.encoding) {
+        println!(
+            "0x{:08x}  {:<8}  \"{}\"",
+            found.offset,
+            found.encoding.label(),
+            search::escape(&found.text)
+        );
+    }
+    Ok(())
+}
+
+fn structure(args: &StructArgs) -> Result<()> {
+    let layout = layout::Layout::parse(&args.layout)?;
+    if args.count == 0 {
+        return Ok(());
+    }
+    let size = file_len(&args.file)?;
+    let record_size = layout.size as u64;
+    let span = record_size
+        .checked_mul(args.count)
+        .and_then(|total| args.offset.checked_add(total))
+        .context("the requested records overflow a 64-bit offset")?;
+    if span > size {
+        bail!(
+            "{} records of {record_size} bytes at 0x{:x} need 0x{span:x} bytes, \
+             but {} is 0x{size:x} bytes",
+            args.count,
+            args.offset,
+            args.file.display()
+        );
+    }
+    let bytes = read_window(&args.file, args.offset, span - args.offset)?;
+    let name_width = layout
+        .fields
+        .iter()
+        .map(|field| field.name.len())
+        .max()
+        .unwrap_or(1);
+    for index in 0..args.count {
+        let start = (index * record_size) as usize;
+        let record = &bytes[start..start + layout.size];
+        let base = args.offset + index * record_size;
+        println!("record {index} @ 0x{base:08x} ({record_size} bytes)");
+        for field in layout.decode(record) {
+            let at = base + field.offset as u64;
+            println!(
+                "  0x{at:08x}  {:<name_width$}  {:<8}  {:<24}  {}",
+                field.name, field.type_name, field.decimal, field.hex
+            );
+        }
+    }
+    Ok(())
+}
+
+fn container_list(args: &ContainerArgs) -> Result<()> {
+    let bytes = read_whole(&args.file)?;
+    let entries = container::list(&bytes, args.limits.limits()).with_context(|| {
+        format!(
+            "{} is not a readable ZIP container; `cadmpeg inspect {}` reads \
+             the other container families through their codec",
+            args.file.display(),
+            args.file.display()
+        )
+    })?;
+    print!("{}", container::render(&entries));
+    Ok(())
+}
+
+fn diff_files(args: &DiffArgs) -> Result<()> {
+    let a = read_whole(&args.a)?;
+    let b = read_whole(&args.b)?;
+    let summary = diff::compare(&a, &b, args.gap);
+    println!(
+        "a: {} ({} bytes)\nb: {} ({} bytes)",
+        args.a.display(),
+        summary.len_a,
+        args.b.display(),
+        summary.len_b
+    );
+    if summary.identical() {
+        println!("identical");
+        return Ok(());
+    }
+    if summary.len_a != summary.len_b {
+        println!(
+            "length differs by {} bytes; only the first {} bytes are compared",
+            summary.len_a.abs_diff(summary.len_b),
+            summary.compared
+        );
+    }
+    let Some(first) = summary.first else {
+        println!("the common prefix is identical");
+        return Ok(());
+    };
+    println!(
+        "first difference: 0x{first:08x} ({first})\ndiffering bytes: {} of {}\nruns (gap {}): {}",
+        summary.differing,
+        summary.compared,
+        args.gap,
+        summary.runs.len()
+    );
+    let shown = if args.max_runs == 0 {
+        summary.runs.len()
+    } else {
+        args.max_runs.min(summary.runs.len())
+    };
+    for run in &summary.runs[..shown] {
+        println!(
+            "  0x{:08x}..0x{:08x}  {} bytes",
+            run.start,
+            run.end(),
+            run.len
+        );
+    }
+    if shown < summary.runs.len() {
+        println!(
+            "  … {} more runs (raise --max-runs)",
+            summary.runs.len() - shown
+        );
+    }
+    if args.context > 0 {
+        let window_start = first.saturating_sub(args.context / 2);
+        println!("\na @ 0x{window_start:x}:");
+        print!("{}", window(&a, window_start, args.context));
+        println!("b @ 0x{window_start:x}:");
+        print!("{}", window(&b, window_start, args.context));
+    }
+    Ok(())
+}
+
+/// Renders a bounded hexadecimal window of an in-memory buffer.
+fn window(bytes: &[u8], start: u64, len: u64) -> String {
+    let begin = usize::try_from(start)
+        .unwrap_or(usize::MAX)
+        .min(bytes.len());
+    let end = usize::try_from(start.saturating_add(len))
+        .unwrap_or(usize::MAX)
+        .min(bytes.len());
+    hexdump::render(begin as u64, &bytes[begin..end], 16)
+}

--- a/crates/cadmpeg/src/inspect/numeric.rs
+++ b/crates/cadmpeg/src/inspect/numeric.rs
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Offset argument parsing and fixed-width scalar reads.
+
+use clap::{Args, ValueEnum};
+
+/// Parses a byte count or file offset written in hexadecimal or decimal.
+///
+/// `0x`/`0X` selects hexadecimal, anything else is decimal. Underscores
+/// separate digit groups and are ignored. The value is unsigned; a leading
+/// sign is rejected so that a mistyped offset never silently wraps.
+pub fn parse_offset(text: &str) -> Result<u64, String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Err("expected a byte offset, found an empty value".to_string());
+    }
+    let (digits, radix) = match trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+    {
+        Some(rest) => (rest, 16),
+        None => (trimmed, 10),
+    };
+    let cleaned: String = digits.chars().filter(|c| *c != '_').collect();
+    if cleaned.is_empty() {
+        return Err(format!("{trimmed}: no digits after the radix prefix"));
+    }
+    if !cleaned.chars().all(|c| c.is_digit(radix)) {
+        let kind = if radix == 16 {
+            "hexadecimal"
+        } else {
+            "decimal"
+        };
+        return Err(format!("{trimmed}: not a {kind} byte offset"));
+    }
+    u64::from_str_radix(&cleaned, radix).map_err(|_| format!("{trimmed}: does not fit in 64 bits"))
+}
+
+/// Byte order applied to a multi-byte scalar read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Endian {
+    /// Least significant byte first.
+    Little,
+    /// Most significant byte first.
+    Big,
+}
+
+impl Endian {
+    /// Returns the two-letter suffix used in output and in layout specs.
+    pub const fn suffix(self) -> &'static str {
+        match self {
+            Self::Little => "le",
+            Self::Big => "be",
+        }
+    }
+}
+
+/// Mutually exclusive byte-order selection flags.
+#[derive(Debug, Clone, Args)]
+pub struct EndianArgs {
+    /// Read little-endian. This is the default.
+    #[arg(long, conflicts_with = "be")]
+    le: bool,
+    /// Read big-endian.
+    #[arg(long)]
+    be: bool,
+}
+
+impl EndianArgs {
+    /// Returns the selected byte order, defaulting to little-endian.
+    pub const fn endian(&self) -> Endian {
+        if self.be {
+            Endian::Big
+        } else {
+            Endian::Little
+        }
+    }
+}
+
+/// A fixed-width scalar that a decoder reads out of a record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ScalarType {
+    /// Unsigned 8-bit.
+    U8,
+    /// Signed 8-bit.
+    I8,
+    /// Unsigned 16-bit.
+    U16,
+    /// Signed 16-bit.
+    I16,
+    /// Unsigned 32-bit.
+    U32,
+    /// Signed 32-bit.
+    I32,
+    /// Unsigned 64-bit.
+    U64,
+    /// Signed 64-bit.
+    I64,
+    /// IEEE-754 binary32.
+    F32,
+    /// IEEE-754 binary64.
+    F64,
+}
+
+impl ScalarType {
+    /// Returns the encoded width in bytes.
+    pub const fn width(self) -> usize {
+        match self {
+            Self::U8 | Self::I8 => 1,
+            Self::U16 | Self::I16 => 2,
+            Self::U32 | Self::I32 | Self::F32 => 4,
+            Self::U64 | Self::I64 | Self::F64 => 8,
+        }
+    }
+
+    /// Returns true when the encoding is one byte wide and byte order is moot.
+    pub const fn is_single_byte(self) -> bool {
+        self.width() == 1
+    }
+
+    /// Returns the spec name without a byte-order suffix.
+    pub const fn base_name(self) -> &'static str {
+        match self {
+            Self::U8 => "u8",
+            Self::I8 => "i8",
+            Self::U16 => "u16",
+            Self::I16 => "i16",
+            Self::U32 => "u32",
+            Self::I32 => "i32",
+            Self::U64 => "u64",
+            Self::I64 => "i64",
+            Self::F32 => "f32",
+            Self::F64 => "f64",
+        }
+    }
+
+    /// Returns the display name, with a byte-order suffix for wide types.
+    pub fn display_name(self, endian: Endian) -> String {
+        if self.is_single_byte() {
+            self.base_name().to_string()
+        } else {
+            format!("{}{}", self.base_name(), endian.suffix())
+        }
+    }
+
+    /// Parses a base type name with no byte-order suffix.
+    pub fn from_base_name(name: &str) -> Option<Self> {
+        [
+            Self::U8,
+            Self::I8,
+            Self::U16,
+            Self::I16,
+            Self::U32,
+            Self::I32,
+            Self::U64,
+            Self::I64,
+            Self::F32,
+            Self::F64,
+        ]
+        .into_iter()
+        .find(|candidate| candidate.base_name() == name)
+    }
+
+    /// Decodes one value from exactly [`ScalarType::width`] bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `bytes` is not exactly the encoded width. Callers slice the
+    /// window before calling, so a mismatch is a programming error.
+    pub fn read(self, bytes: &[u8], endian: Endian) -> ScalarValue {
+        assert_eq!(
+            bytes.len(),
+            self.width(),
+            "scalar read needs an exact slice"
+        );
+        let mut raw = [0u8; 8];
+        raw[..bytes.len()].copy_from_slice(bytes);
+        if endian == Endian::Big {
+            raw[..bytes.len()].reverse();
+        }
+        // `raw` now holds the value little-endian in its low `width` bytes.
+        let bits = u64::from_le_bytes(raw);
+        match self {
+            Self::U8 | Self::U16 | Self::U32 | Self::U64 => ScalarValue::Unsigned(bits),
+            Self::I8 | Self::I16 | Self::I32 | Self::I64 => {
+                let shift = 64 - self.width() * 8;
+                ScalarValue::Signed(((bits << shift) as i64) >> shift)
+            }
+            Self::F32 => ScalarValue::Float(f64::from(f32::from_bits(bits as u32))),
+            Self::F64 => ScalarValue::Float(f64::from_bits(bits)),
+        }
+    }
+}
+
+/// A decoded scalar, kept in the widest lane of its numeric family.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ScalarValue {
+    /// An unsigned integer, zero-extended.
+    Unsigned(u64),
+    /// A signed integer, sign-extended.
+    Signed(i64),
+    /// A floating-point value, widened to binary64.
+    Float(f64),
+}
+
+impl ScalarValue {
+    /// Renders the value the way a human reads it.
+    pub fn decimal(self) -> String {
+        match self {
+            Self::Unsigned(value) => value.to_string(),
+            Self::Signed(value) => value.to_string(),
+            Self::Float(value) => format!("{value:?}"),
+        }
+    }
+
+    /// Renders the encoded bit pattern, zero-padded to the type width.
+    ///
+    /// Signed values print their two's-complement pattern and floats print
+    /// their IEEE-754 bits, so the text always matches what is in the file.
+    pub fn hex(self, ty: ScalarType) -> String {
+        let digits = ty.width() * 2;
+        let bits = match self {
+            Self::Unsigned(value) => value,
+            Self::Signed(value) => (value as u64) & mask(ty.width()),
+            Self::Float(value) => {
+                if ty == ScalarType::F32 {
+                    u64::from((value as f32).to_bits())
+                } else {
+                    value.to_bits()
+                }
+            }
+        };
+        format!("0x{bits:0digits$x}")
+    }
+}
+
+/// Returns a low-`width`-byte mask, saturating at the full 64-bit word.
+const fn mask(width: usize) -> u64 {
+    if width >= 8 {
+        u64::MAX
+    } else {
+        (1u64 << (width * 8)) - 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_offset_reads_both_radixes() {
+        assert_eq!(parse_offset("0"), Ok(0));
+        assert_eq!(parse_offset("4096"), Ok(4096));
+        assert_eq!(parse_offset("0x1000"), Ok(4096));
+        assert_eq!(parse_offset("0X1000"), Ok(4096));
+        assert_eq!(parse_offset("  0x1_0000 "), Ok(65536));
+        assert_eq!(parse_offset("1_000"), Ok(1000));
+    }
+
+    #[test]
+    fn parse_offset_rejects_garbage() {
+        for bad in ["", "   ", "0x", "-1", "+1", "12g", "0xzz", "1.5", "0b101"] {
+            assert!(parse_offset(bad).is_err(), "{bad} should not parse");
+        }
+    }
+
+    #[test]
+    fn parse_offset_rejects_overflow() {
+        assert_eq!(parse_offset("0xffffffffffffffff"), Ok(u64::MAX));
+        assert!(parse_offset("0x1_0000_0000_0000_0000").is_err());
+    }
+
+    #[test]
+    fn unsigned_reads_follow_byte_order() {
+        // 0x0102 big-endian is 258; the same bytes little-endian are 0x0201.
+        let bytes = [0x01, 0x02];
+        assert_eq!(
+            ScalarType::U16.read(&bytes, Endian::Big),
+            ScalarValue::Unsigned(258)
+        );
+        assert_eq!(
+            ScalarType::U16.read(&bytes, Endian::Little),
+            ScalarValue::Unsigned(513)
+        );
+    }
+
+    #[test]
+    fn signed_reads_sign_extend_at_each_width() {
+        assert_eq!(
+            ScalarType::I8.read(&[0xff], Endian::Little),
+            ScalarValue::Signed(-1)
+        );
+        assert_eq!(
+            ScalarType::I16.read(&[0x00, 0x80], Endian::Little),
+            ScalarValue::Signed(-32768)
+        );
+        assert_eq!(
+            ScalarType::I32.read(&[0xff, 0xff, 0xff, 0xff], Endian::Big),
+            ScalarValue::Signed(-1)
+        );
+        assert_eq!(
+            ScalarType::I64.read(&[0, 0, 0, 0, 0, 0, 0, 0x80], Endian::Little),
+            ScalarValue::Signed(i64::MIN)
+        );
+    }
+
+    #[test]
+    fn float_reads_match_hand_built_bit_patterns() {
+        // 1.5f64 is sign 0, exponent 0x3ff, mantissa 0x8000000000000.
+        let one_point_five = 0x3ff8_0000_0000_0000u64.to_le_bytes();
+        assert_eq!(
+            ScalarType::F64.read(&one_point_five, Endian::Little),
+            ScalarValue::Float(1.5)
+        );
+        // -2.0f32 is sign 1, exponent 0x80, mantissa 0.
+        let minus_two = 0xc000_0000u32.to_be_bytes();
+        assert_eq!(
+            ScalarType::F32.read(&minus_two, Endian::Big),
+            ScalarValue::Float(-2.0)
+        );
+    }
+
+    #[test]
+    fn hex_rendering_pads_to_the_type_width() {
+        assert_eq!(ScalarValue::Unsigned(1).hex(ScalarType::U32), "0x00000001");
+        assert_eq!(ScalarValue::Signed(-1).hex(ScalarType::I16), "0xffff");
+        assert_eq!(
+            ScalarValue::Signed(-1).hex(ScalarType::I64),
+            "0xffffffffffffffff"
+        );
+        assert_eq!(
+            ScalarValue::Float(1.5).hex(ScalarType::F64),
+            "0x3ff8000000000000"
+        );
+        assert_eq!(ScalarValue::Float(-2.0).hex(ScalarType::F32), "0xc0000000");
+    }
+
+    #[test]
+    fn display_names_carry_a_suffix_only_for_wide_types() {
+        assert_eq!(ScalarType::U8.display_name(Endian::Big), "u8");
+        assert_eq!(ScalarType::F64.display_name(Endian::Big), "f64be");
+    }
+}

--- a/crates/cadmpeg/src/inspect/search.rs
+++ b/crates/cadmpeg/src/inspect/search.rs
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Byte-pattern search and printable-string extraction.
+
+/// One byte of a search pattern: a fixed value or a `??` wildcard.
+pub type PatternByte = Option<u8>;
+
+/// Parses a hexadecimal search pattern.
+///
+/// Digits are read in pairs. `??` matches any byte. Whitespace between pairs is
+/// ignored, so `4d 5a ?? 00` and `4d5a??00` are the same pattern.
+///
+/// # Errors
+///
+/// Returns a message when the pattern is empty, holds a character that is
+/// neither a hexadecimal digit nor `?`, mixes a digit with `?` inside one pair,
+/// or ends on a half byte.
+pub fn parse_pattern(text: &str) -> Result<Vec<PatternByte>, String> {
+    let chars: Vec<char> = text.chars().filter(|c| !c.is_whitespace()).collect();
+    if chars.is_empty() {
+        return Err(
+            "empty pattern; expected hexadecimal byte pairs such as `4d5a??00`".to_string(),
+        );
+    }
+    if !chars.len().is_multiple_of(2) {
+        return Err(format!(
+            "pattern `{text}` has {} hexadecimal digits; byte patterns need an even count",
+            chars.len()
+        ));
+    }
+    let mut pattern = Vec::with_capacity(chars.len() / 2);
+    for pair in chars.chunks(2) {
+        let (high, low) = (pair[0], pair[1]);
+        match (high, low) {
+            ('?', '?') => pattern.push(None),
+            ('?', _) | (_, '?') => {
+                return Err(format!(
+                    "pattern `{text}`: `{high}{low}` mixes a wildcard with a digit; \
+                     a wildcard covers a whole byte and is written `??`"
+                ))
+            }
+            _ => {
+                let high = hex_digit(high, text)?;
+                let low = hex_digit(low, text)?;
+                pattern.push(Some(high << 4 | low));
+            }
+        }
+    }
+    Ok(pattern)
+}
+
+fn hex_digit(c: char, text: &str) -> Result<u8, String> {
+    c.to_digit(16)
+        .map(|value| value as u8)
+        .ok_or_else(|| format!("pattern `{text}`: `{c}` is not a hexadecimal digit or `?`"))
+}
+
+/// Encodes an ASCII search term, rejecting anything outside 7-bit ASCII.
+///
+/// # Errors
+///
+/// Returns a message when the term is empty or holds a non-ASCII character.
+pub fn ascii_pattern(text: &str) -> Result<Vec<PatternByte>, String> {
+    if text.is_empty() {
+        return Err("empty ASCII search term".to_string());
+    }
+    if !text.is_ascii() {
+        return Err(format!(
+            "`{text}` is not ASCII; use --utf16le or --hex for other encodings"
+        ));
+    }
+    Ok(text.bytes().map(Some).collect())
+}
+
+/// Encodes a search term as UTF-16LE code units.
+///
+/// # Errors
+///
+/// Returns a message when the term is empty.
+pub fn utf16le_pattern(text: &str) -> Result<Vec<PatternByte>, String> {
+    if text.is_empty() {
+        return Err("empty UTF-16LE search term".to_string());
+    }
+    Ok(text
+        .encode_utf16()
+        .flat_map(u16::to_le_bytes)
+        .map(Some)
+        .collect())
+}
+
+/// Returns every offset in `haystack` where `pattern` matches, in order.
+///
+/// `limit` caps the number of reported offsets; `None` reports all of them. The
+/// match is byte exact except at wildcard positions.
+pub fn find_all(haystack: &[u8], pattern: &[PatternByte], limit: Option<usize>) -> Vec<u64> {
+    let mut hits = Vec::new();
+    if pattern.is_empty() || haystack.len() < pattern.len() {
+        return hits;
+    }
+    // Anchoring on a fixed byte lets `memchr` skip most of the file when the
+    // pattern does not start with a wildcard.
+    let anchor = pattern.iter().position(Option::is_some);
+    let last_start = haystack.len() - pattern.len();
+    let mut start = 0usize;
+    while start <= last_start {
+        let candidate = match anchor {
+            Some(index) => {
+                let byte = pattern[index].expect("anchor position holds a fixed byte");
+                match memchr::memchr(byte, &haystack[start + index..]) {
+                    Some(found) => start + found,
+                    None => break,
+                }
+            }
+            None => start,
+        };
+        if candidate > last_start {
+            break;
+        }
+        if matches_at(haystack, candidate, pattern) {
+            hits.push(candidate as u64);
+            if limit.is_some_and(|max| hits.len() >= max) {
+                break;
+            }
+        }
+        start = candidate + 1;
+    }
+    hits
+}
+
+fn matches_at(haystack: &[u8], at: usize, pattern: &[PatternByte]) -> bool {
+    pattern
+        .iter()
+        .zip(&haystack[at..at + pattern.len()])
+        .all(|(expected, actual)| expected.is_none_or(|byte| byte == *actual))
+}
+
+/// Character encoding recognised by the string extractor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum StringEncoding {
+    /// Runs of printable single-byte ASCII.
+    Ascii,
+    /// Runs of printable ASCII widened to UTF-16LE code units.
+    Utf16le,
+    /// Both of the above, merged and sorted by offset.
+    Both,
+}
+
+impl StringEncoding {
+    /// Returns the label printed next to each extracted string.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Ascii => "ascii",
+            Self::Utf16le => "utf16le",
+            Self::Both => "both",
+        }
+    }
+}
+
+/// One printable run found in a file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FoundString {
+    /// Offset of the first byte of the run.
+    pub offset: u64,
+    /// Encoding the run was read in.
+    pub encoding: StringEncoding,
+    /// The decoded text.
+    pub text: String,
+}
+
+/// Extracts printable runs of at least `min_len` characters.
+///
+/// Runs are maximal: a longer run is never reported as several shorter ones. For
+/// [`StringEncoding::Both`] the ASCII and UTF-16LE passes run independently and
+/// the results are sorted by offset, so a UTF-16LE run is also visible as the
+/// ASCII characters interleaved with its zero bytes only when those characters
+/// themselves form a long enough ASCII run.
+pub fn extract_strings(bytes: &[u8], min_len: usize, encoding: StringEncoding) -> Vec<FoundString> {
+    let min_len = min_len.max(1);
+    let mut found = match encoding {
+        StringEncoding::Ascii => ascii_runs(bytes, min_len),
+        StringEncoding::Utf16le => utf16le_runs(bytes, min_len),
+        StringEncoding::Both => {
+            let mut all = ascii_runs(bytes, min_len);
+            all.extend(utf16le_runs(bytes, min_len));
+            all
+        }
+    };
+    found.sort_by_key(|item| (item.offset, item.text.len()));
+    found
+}
+
+const fn is_printable(byte: u8) -> bool {
+    byte.is_ascii_graphic() || byte == b' ' || byte == b'\t'
+}
+
+fn ascii_runs(bytes: &[u8], min_len: usize) -> Vec<FoundString> {
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    let mut run = String::new();
+    for (index, byte) in bytes.iter().enumerate() {
+        if is_printable(*byte) {
+            if run.is_empty() {
+                start = index;
+            }
+            run.push(*byte as char);
+        } else if long_enough(&run, min_len) {
+            out.push(FoundString {
+                offset: start as u64,
+                encoding: StringEncoding::Ascii,
+                text: std::mem::take(&mut run),
+            });
+        } else {
+            run.clear();
+        }
+    }
+    if long_enough(&run, min_len) {
+        out.push(FoundString {
+            offset: start as u64,
+            encoding: StringEncoding::Ascii,
+            text: run,
+        });
+    }
+    out
+}
+
+fn utf16le_runs(bytes: &[u8], min_len: usize) -> Vec<FoundString> {
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    let mut run = String::new();
+    let mut index = 0usize;
+    while index + 1 < bytes.len() {
+        if is_printable(bytes[index]) && bytes[index + 1] == 0 {
+            if run.is_empty() {
+                start = index;
+            }
+            run.push(bytes[index] as char);
+            index += 2;
+            continue;
+        }
+        if long_enough(&run, min_len) {
+            out.push(FoundString {
+                offset: start as u64,
+                encoding: StringEncoding::Utf16le,
+                text: std::mem::take(&mut run),
+            });
+        } else {
+            run.clear();
+        }
+        index += 1;
+    }
+    if long_enough(&run, min_len) {
+        out.push(FoundString {
+            offset: start as u64,
+            encoding: StringEncoding::Utf16le,
+            text: run,
+        });
+    }
+    out
+}
+
+/// Reports whether the pending run is long enough to emit.
+fn long_enough(run: &str, min_len: usize) -> bool {
+    run.chars().count() >= min_len
+}
+
+/// Escapes a decoded string for single-line output.
+pub fn escape(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 2);
+    for c in text.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_patterns_with_and_without_wildcards() {
+        assert_eq!(parse_pattern("4d5a"), Ok(vec![Some(0x4d), Some(0x5a)]));
+        assert_eq!(parse_pattern("4d 5a"), Ok(vec![Some(0x4d), Some(0x5a)]));
+        assert_eq!(
+            parse_pattern("4d??00"),
+            Ok(vec![Some(0x4d), None, Some(0x00)])
+        );
+        assert_eq!(parse_pattern("AB"), Ok(vec![Some(0xab)]));
+        assert_eq!(parse_pattern("????"), Ok(vec![None, None]));
+    }
+
+    #[test]
+    fn rejects_malformed_patterns() {
+        for bad in ["", "   ", "4", "4d5", "zz", "4?", "?d", "4d 5"] {
+            assert!(parse_pattern(bad).is_err(), "{bad:?} should not parse");
+        }
+    }
+
+    #[test]
+    fn encodes_text_search_terms() {
+        assert_eq!(ascii_pattern("Hi"), Ok(vec![Some(b'H'), Some(b'i')]));
+        assert_eq!(
+            utf16le_pattern("Hi"),
+            Ok(vec![Some(b'H'), Some(0), Some(b'i'), Some(0)])
+        );
+        assert!(ascii_pattern("").is_err());
+        assert!(ascii_pattern("é").is_err());
+        assert!(utf16le_pattern("").is_err());
+    }
+
+    #[test]
+    fn finds_every_occurrence_including_overlaps() {
+        let haystack = b"aaaa";
+        let pattern = ascii_pattern("aa").unwrap();
+        assert_eq!(find_all(haystack, &pattern, None), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn honours_wildcards_and_the_result_limit() {
+        // Hand-built: "ax1" at 0, "ay1" at 3, "az1" at 6.
+        let haystack = b"ax1ay1az1";
+        let pattern = parse_pattern("61??31").unwrap();
+        assert_eq!(find_all(haystack, &pattern, None), vec![0, 3, 6]);
+        assert_eq!(find_all(haystack, &pattern, Some(2)), vec![0, 3]);
+    }
+
+    #[test]
+    fn matches_a_leading_wildcard_pattern() {
+        let haystack = &[0x00, 0x11, 0x22, 0x11, 0x22];
+        let pattern = parse_pattern("??1122").unwrap();
+        assert_eq!(find_all(haystack, &pattern, None), vec![0, 2]);
+    }
+
+    #[test]
+    fn reports_nothing_when_the_pattern_is_longer_than_the_file() {
+        assert_eq!(
+            find_all(b"ab", &parse_pattern("616263").unwrap(), None),
+            Vec::<u64>::new()
+        );
+    }
+
+    #[test]
+    fn extracts_maximal_ascii_runs_over_the_minimum_length() {
+        let bytes = b"\x00abcd\x00ef\x00longer-name\x00";
+        let found = extract_strings(bytes, 4, StringEncoding::Ascii);
+        let texts: Vec<&str> = found.iter().map(|item| item.text.as_str()).collect();
+        assert_eq!(texts, ["abcd", "longer-name"]);
+        assert_eq!(found[0].offset, 1);
+        assert_eq!(found[1].offset, 9);
+    }
+
+    #[test]
+    fn extracts_utf16le_runs() {
+        let mut bytes = vec![0xffu8];
+        for c in "Part1".bytes() {
+            bytes.push(c);
+            bytes.push(0);
+        }
+        bytes.push(0xff);
+        let found = extract_strings(&bytes, 4, StringEncoding::Utf16le);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].text, "Part1");
+        assert_eq!(found[0].offset, 1);
+    }
+
+    #[test]
+    fn both_encodings_are_merged_and_sorted_by_offset() {
+        let mut bytes = b"header".to_vec();
+        bytes.push(0xff);
+        for c in "wide".bytes() {
+            bytes.push(c);
+            bytes.push(0);
+        }
+        let found = extract_strings(&bytes, 4, StringEncoding::Both);
+        let pairs: Vec<(u64, &str)> = found
+            .iter()
+            .map(|item| (item.offset, item.text.as_str()))
+            .collect();
+        assert_eq!(pairs, [(0, "header"), (7, "wide")]);
+    }
+
+    #[test]
+    fn escapes_quotes_backslashes_and_tabs() {
+        assert_eq!(escape("a\"b\\c\td"), "a\\\"b\\\\c\\td");
+    }
+}

--- a/crates/cadmpeg/src/main.rs
+++ b/crates/cadmpeg/src/main.rs
@@ -8,6 +8,7 @@
 //! limits, loss reporting, and exit-status semantics.
 
 mod commands;
+mod inspect;
 mod loader;
 mod registry;
 
@@ -274,10 +275,15 @@ impl LimitProfile {
 
 #[derive(Debug, Subcommand)]
 enum Command {
-    /// List a native container's entries without decoding its model.
+    /// List a native container's entries, or run a byte-level subcommand.
+    ///
+    /// With a file argument this prints the codec-aware container summary. With
+    /// a subcommand it runs a format-agnostic byte tool over any file.
+    #[command(args_conflicts_with_subcommands = true, subcommand_negates_reqs = true)]
     Inspect {
-        /// Native CAD file to inspect.
-        input: PathBuf,
+        /// Native CAD file to inspect. Omit it when using a byte subcommand.
+        #[arg(required = true)]
+        input: Option<PathBuf>,
         /// Write a versioned JSON summary to standard output.
         #[arg(long)]
         json: bool,
@@ -289,6 +295,9 @@ enum Command {
         limits: LimitProfile,
         #[command(flatten)]
         input_args: InputArgs,
+        /// Byte-level tool to run instead of the container summary.
+        #[command(subcommand)]
+        bytes: Option<inspect::ByteCommand>,
     },
     /// Decode a native CAD file to canonical CADIR JSON.
     Decode {
@@ -423,15 +432,22 @@ fn main() -> ExitCode {
             report,
             limits,
             input_args,
-        } => commands::inspect(
-            &registry,
-            &input,
-            input_args.forced(),
-            json,
-            report.as_deref(),
-            limits.limits(),
-        )
-        .map(|()| ExitCode::SUCCESS),
+            bytes,
+        } => match bytes {
+            Some(byte_command) => inspect::run(byte_command).map(|()| ExitCode::SUCCESS),
+            None => {
+                let input = input.expect("clap requires an input without a subcommand");
+                commands::inspect(
+                    &registry,
+                    &input,
+                    input_args.forced(),
+                    json,
+                    report.as_deref(),
+                    limits.limits(),
+                )
+                .map(|()| ExitCode::SUCCESS)
+            }
+        },
         Command::Decode {
             input,
             output,

--- a/crates/cadmpeg/tests/inspect_bytes.rs
+++ b/crates/cadmpeg/tests/inspect_bytes.rs
@@ -1,0 +1,479 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Integration tests for the `cadmpeg inspect` byte subcommands.
+//!
+//! Every fixture is built here from literal bytes, so each expected value is
+//! derived from the construction rather than read back from a run.
+
+#![allow(clippy::unwrap_used)]
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::tempdir;
+
+/// Writes `bytes` to `name` inside `dir` and returns the path.
+fn write(dir: &Path, name: &str, bytes: &[u8]) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, bytes).unwrap();
+    path
+}
+
+/// A 36-byte record: a 4-byte tag, a little-endian count, four padding bytes,
+/// then two big-endian binary64 values and an 8-byte ASCII name.
+fn record_fixture() -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"RECS");
+    bytes.extend_from_slice(&2u32.to_le_bytes());
+    bytes.extend_from_slice(&[0xaa; 4]);
+    // 1.5 is 0x3ff8_0000_0000_0000; -0.5 is 0xbfe0_0000_0000_0000.
+    bytes.extend_from_slice(&0x3ff8_0000_0000_0000u64.to_be_bytes());
+    bytes.extend_from_slice(&0xbfe0_0000_0000_0000u64.to_be_bytes());
+    bytes.extend_from_slice(b"widget00");
+    assert_eq!(bytes.len(), 4 + 4 + 4 + 8 + 8 + 8);
+    bytes
+}
+
+fn cadmpeg() -> Command {
+    Command::cargo_bin("cadmpeg").unwrap()
+}
+
+#[test]
+fn hex_dumps_an_absolute_window_and_accepts_hex_arguments() {
+    let dir = tempdir().unwrap();
+    let bytes: Vec<u8> = (0u8..64).collect();
+    let file = write(dir.path(), "counter.bin", &bytes);
+
+    // Offsets 0x10..0x20 hold the bytes 16..32.
+    cadmpeg()
+        .args([
+            "inspect",
+            "hex",
+            file.to_str().unwrap(),
+            "--offset",
+            "0x10",
+            "--len",
+            "0x10",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            "00000010  10 11 12 13 14 15 16 17  18 19 1a 1b 1c 1d 1e 1f  \
+             |................|\n",
+        );
+
+    // The same window written in decimal must produce the same dump.
+    cadmpeg()
+        .args([
+            "inspect",
+            "hex",
+            file.to_str().unwrap(),
+            "--offset",
+            "16",
+            "--len",
+            "16",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with("00000010  10 11 12 13"));
+}
+
+#[test]
+fn hex_stops_at_end_of_file_and_rejects_an_offset_past_it() {
+    let dir = tempdir().unwrap();
+    let file = write(dir.path(), "short.bin", b"abc");
+
+    cadmpeg()
+        .args(["inspect", "hex", file.to_str().unwrap(), "--len", "0x100"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("|abc|"));
+
+    cadmpeg()
+        .args(["inspect", "hex", file.to_str().unwrap(), "--offset", "4"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("past the end"));
+}
+
+#[test]
+fn read_walks_a_record_array_with_an_explicit_stride() {
+    let dir = tempdir().unwrap();
+    // Three u16be counts at offsets 0, 6 and 12, with four filler bytes between.
+    let mut bytes = Vec::new();
+    for count in [7u16, 8, 9] {
+        bytes.extend_from_slice(&count.to_be_bytes());
+        bytes.extend_from_slice(&[0xff; 4]);
+    }
+    let file = write(dir.path(), "array.bin", &bytes);
+
+    cadmpeg()
+        .args([
+            "inspect",
+            "read",
+            file.to_str().unwrap(),
+            "--type",
+            "u16",
+            "--be",
+            "--count",
+            "3",
+            "--stride",
+            "6",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            "0x00000000  u16be   7                         0x0007\n\
+             0x00000006  u16be   8                         0x0008\n\
+             0x0000000c  u16be   9                         0x0009\n",
+        );
+}
+
+#[test]
+fn read_defaults_to_little_endian_and_reports_a_read_past_the_end() {
+    let dir = tempdir().unwrap();
+    // 0x0102 little-endian is 513; the same bytes big-endian are 258.
+    let file = write(dir.path(), "pair.bin", &[0x01, 0x02]);
+
+    cadmpeg()
+        .args(["inspect", "read", file.to_str().unwrap(), "--type", "u16"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("513"));
+
+    cadmpeg()
+        .args(["inspect", "read", file.to_str().unwrap(), "--type", "u32"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("past the end"));
+}
+
+#[test]
+fn find_reports_pattern_string_and_wildcard_hits() {
+    let dir = tempdir().unwrap();
+    let mut bytes = b"prefix".to_vec();
+    bytes.extend_from_slice(&[0x4d, 0x5a, 0x01, 0x00]);
+    bytes.extend_from_slice(&[0x4d, 0x5a, 0x02, 0x00]);
+    for unit in "Part".encode_utf16() {
+        bytes.extend_from_slice(&unit.to_le_bytes());
+    }
+    // "prefix" is 6 bytes, so the two 4-byte stubs sit at 6 and 10 and the
+    // UTF-16LE text starts at 14.
+    let file = write(dir.path(), "hits.bin", &bytes);
+
+    cadmpeg()
+        .args([
+            "inspect",
+            "find",
+            file.to_str().unwrap(),
+            "--hex",
+            "4d5a??00",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("hits: 2")
+                .and(predicate::str::contains("0x00000006"))
+                .and(predicate::str::contains("0x0000000a")),
+        );
+
+    cadmpeg()
+        .args([
+            "inspect",
+            "find",
+            file.to_str().unwrap(),
+            "--ascii",
+            "prefix",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0x00000000"));
+
+    cadmpeg()
+        .args([
+            "inspect",
+            "find",
+            file.to_str().unwrap(),
+            "--utf16le",
+            "Part",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hits: 1").and(predicate::str::contains("0x0000000e")));
+}
+
+#[test]
+fn find_rejects_a_malformed_pattern_and_a_missing_needle() {
+    let dir = tempdir().unwrap();
+    let file = write(dir.path(), "empty.bin", b"");
+
+    cadmpeg()
+        .args(["inspect", "find", file.to_str().unwrap(), "--hex", "4d5"])
+        .assert()
+        .code(2);
+
+    cadmpeg()
+        .args(["inspect", "find", file.to_str().unwrap()])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn strings_honours_the_minimum_length_and_the_encoding() {
+    let dir = tempdir().unwrap();
+    let mut bytes = vec![0x00];
+    bytes.extend_from_slice(b"body");
+    bytes.push(0x00);
+    bytes.extend_from_slice(b"no");
+    bytes.push(0xff);
+    for unit in "sketch".encode_utf16() {
+        bytes.extend_from_slice(&unit.to_le_bytes());
+    }
+    // "body" is at 1; "no" is at 6 and is below the minimum; the UTF-16LE run
+    // starts at 9.
+    let file = write(dir.path(), "text.bin", &bytes);
+
+    cadmpeg()
+        .args(["inspect", "strings", file.to_str().unwrap(), "--min", "4"])
+        .assert()
+        .success()
+        .stdout("0x00000001  ascii     \"body\"\n");
+
+    cadmpeg()
+        .args([
+            "inspect",
+            "strings",
+            file.to_str().unwrap(),
+            "--min",
+            "4",
+            "--encoding",
+            "utf16le",
+        ])
+        .assert()
+        .success()
+        .stdout("0x00000009  utf16le   \"sketch\"\n");
+}
+
+#[test]
+fn struct_decodes_consecutive_records() {
+    let dir = tempdir().unwrap();
+    let mut bytes = record_fixture();
+    bytes.extend_from_slice(&record_fixture());
+    let file = write(dir.path(), "records.bin", &bytes);
+
+    cadmpeg()
+        .args([
+            "inspect",
+            "struct",
+            file.to_str().unwrap(),
+            "--layout",
+            "bytes4:tag,u32le:count,pad4,f64be:x,f64be:y,bytes8:name",
+            "--count",
+            "2",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("record 0 @ 0x00000000 (36 bytes)")
+                .and(predicate::str::contains("record 1 @ 0x00000024 (36 bytes)"))
+                .and(predicate::str::contains("52 45 43 53"))
+                .and(predicate::str::contains("0x3ff8000000000000"))
+                .and(predicate::str::contains("-0.5"))
+                .and(predicate::str::contains("count  u32le     2")),
+        );
+}
+
+#[test]
+fn struct_rejects_a_bad_layout_and_a_run_past_the_end() {
+    let dir = tempdir().unwrap();
+    let file = write(dir.path(), "records.bin", &record_fixture());
+
+    cadmpeg()
+        .args([
+            "inspect",
+            "struct",
+            file.to_str().unwrap(),
+            "--layout",
+            "u32:count",
+        ])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("byte-order suffix"));
+
+    cadmpeg()
+        .args([
+            "inspect",
+            "struct",
+            file.to_str().unwrap(),
+            "--layout",
+            "u32le:count",
+            "--count",
+            "100",
+        ])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("bytes"));
+}
+
+#[test]
+fn container_lists_zip_entries_with_shell_safe_names() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("model.f3d");
+    let file = fs::File::create(&path).unwrap();
+    let mut archive = zip::ZipWriter::new(file);
+    let stored =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    archive
+        .start_file("FusionAssetName[Active]/Design.dat", stored)
+        .unwrap();
+    archive.write_all(b"payload").unwrap();
+    archive.finish().unwrap();
+
+    cadmpeg()
+        .args(["inspect", "container", path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("'FusionAssetName[Active]/Design.dat'")
+                .and(predicate::str::contains("stored"))
+                // "payload" is 7 stored bytes, so packed and unpacked agree.
+                .and(predicate::str::contains("7             7")),
+        );
+}
+
+#[test]
+fn container_refuses_a_file_that_is_not_a_zip() {
+    let dir = tempdir().unwrap();
+    let file = write(dir.path(), "plain.bin", b"not a zip archive at all");
+
+    cadmpeg()
+        .args(["inspect", "container", file.to_str().unwrap()])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("not a readable ZIP container"));
+}
+
+#[test]
+fn diff_reports_identity_length_and_the_first_difference() {
+    let dir = tempdir().unwrap();
+    let base: Vec<u8> = (0u8..32).collect();
+    let same = write(dir.path(), "same.bin", &base);
+    let copy = write(dir.path(), "copy.bin", &base);
+
+    cadmpeg()
+        .args([
+            "inspect",
+            "diff",
+            same.to_str().unwrap(),
+            copy.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("identical"));
+
+    // Change byte 5 and byte 20, then append two bytes.
+    let mut variant = base.clone();
+    variant[5] = 0xff;
+    variant[20] = 0xff;
+    variant.extend_from_slice(&[0xee, 0xee]);
+    let other = write(dir.path(), "variant.bin", &variant);
+
+    cadmpeg()
+        .args([
+            "inspect",
+            "diff",
+            same.to_str().unwrap(),
+            other.to_str().unwrap(),
+            "--gap",
+            "0",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("first difference: 0x00000005 (5)")
+                .and(predicate::str::contains("differing bytes: 2 of 32"))
+                .and(predicate::str::contains("length differs by 2 bytes"))
+                .and(predicate::str::contains("0x00000005..0x00000006"))
+                .and(predicate::str::contains("0x00000014..0x00000015")),
+        );
+}
+
+#[test]
+fn diff_coalesces_runs_at_the_requested_gap() {
+    let dir = tempdir().unwrap();
+    let base = vec![0u8; 16];
+    let mut variant = base.clone();
+    // Differ at 2 and 6, leaving three equal bytes between the two spans.
+    variant[2] = 1;
+    variant[6] = 1;
+    let a = write(dir.path(), "a.bin", &base);
+    let b = write(dir.path(), "b.bin", &variant);
+
+    cadmpeg()
+        .args([
+            "inspect",
+            "diff",
+            a.to_str().unwrap(),
+            b.to_str().unwrap(),
+            "--gap",
+            "3",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("runs (gap 3): 1")
+                .and(predicate::str::contains("0x00000002..0x00000007  5 bytes")),
+        );
+}
+
+#[test]
+fn inspect_without_a_subcommand_still_runs_the_container_summary() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("document.FCStd");
+    let file = fs::File::create(&path).unwrap();
+    let mut archive = zip::ZipWriter::new(file);
+    archive
+        .start_file(
+            "Document.xml",
+            zip::write::SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Stored),
+        )
+        .unwrap();
+    archive
+        .write_all(
+            b"<Document SchemaVersion=\"4\" FileVersion=\"1\" ProgramVersion=\"1.0\">\
+              <Object/></Document>",
+        )
+        .unwrap();
+    archive.finish().unwrap();
+
+    cadmpeg()
+        .args(["inspect", path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("format: fcstd (detected high)"));
+}
+
+#[test]
+fn inspect_without_an_input_or_a_subcommand_is_a_usage_error() {
+    cadmpeg()
+        .arg("inspect")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Usage").and(predicate::str::contains("INPUT")));
+}
+
+#[test]
+fn inspect_help_lists_every_byte_subcommand() {
+    let mut expected = predicate::str::contains("hex").boxed();
+    for name in ["read", "find", "strings", "struct", "container", "diff"] {
+        expected = expected.and(predicate::str::contains(name)).boxed();
+    }
+    cadmpeg()
+        .args(["inspect", "--help"])
+        .assert()
+        .success()
+        .stdout(expected);
+}

--- a/crates/cadmpeg/tests/inspect_bytes.rs
+++ b/crates/cadmpeg/tests/inspect_bytes.rs
@@ -352,7 +352,7 @@ fn container_refuses_a_file_that_is_not_a_zip() {
         .args(["inspect", "container", file.to_str().unwrap()])
         .assert()
         .code(2)
-        .stderr(predicate::str::contains("not a readable ZIP container"));
+        .stderr(predicate::str::contains("as a ZIP container"));
 }
 
 #[test]


### PR DESCRIPTION
## Why

Format work on the binary codecs is byte archaeology, and the toolkit for it lives outside the repository: `xxd` windows, `od` scalar reads, `strings`, `python3 -c 'struct.unpack(...)'`, and `cmp` on probe variants. Each is retyped from scratch every session, each carries its own offset convention, and none agrees with the offsets a codec reports. Putting the same operations in the CLI makes them repeatable and lets a finding be pasted as a command someone else can rerun.

## What

`cadmpeg inspect` grows byte subcommands. All of them read a file as bytes and never invoke a codec, so they work on probe variants that no codec accepts.

| Subcommand | Purpose |
| --- | --- |
| `inspect hex FILE --offset N --len N [--width N]` | Dump with absolute offsets and an ASCII gutter. |
| `inspect read FILE --type u32 --offset N [--le\|--be] [--count N] [--stride M]` | Scalar reads, decimal and hexadecimal, walking a record array. |
| `inspect find FILE (--hex PAT \| --ascii S \| --utf16le S) [--max N]` | Offsets of a pattern; `??` is a byte wildcard. |
| `inspect strings FILE [--min N] [--encoding ascii\|utf16le\|both]` | Printable runs. |
| `inspect struct FILE --layout SPEC --offset N [--count N]` | Decode records with an inline layout spec. |
| `inspect container FILE` | ZIP entries with local-header and payload offsets. |
| `inspect diff A B [--gap N] [--max-runs N] [--context N]` | Positional byte diff. |

Offsets and lengths accept `0x` hexadecimal or decimal with `_` between digits, everywhere.

The `--layout` mini-language is a comma-separated record spec with no implicit alignment: `u8`/`i8` (suffix rejected), `u16le`/`i32be`/`f64le`/… (suffix required), `bytesN`, `padN` (skipped, unnamed). Each non-pad field takes an optional `:name`; unnamed fields become `f<index>`.

## Design decisions

**1. Sub-subcommands under the existing `inspect`, not a new top-level verb.**
`inspect` was already taken by the codec-aware container summary. `cadmpeg inspect FILE` still does exactly what it did; `args_conflicts_with_subcommands` plus `subcommand_negates_reqs` let the positional path and the subcommand path coexist. *Evidence:* no existing invocation changes, and `inspect` is where a reader looks for "show me what is in this file". *Counter-evidence:* a file literally named `hex` or `diff` is now read as a subcommand — documented, with `./hex` as the workaround. A separate `cadmpeg bytes` verb would avoid the collision entirely. *Confidence: medium.* This is the decision most worth overruling.

**2. `inspect diff` is positional, not an edit script.** Byte `n` versus byte `n`. Probe variants from one exporter keep their field offsets, so a positional diff points at the changed fields; an inserted byte shows up as one long run, which is itself the signal that the files are not positional variants. *Confidence: high* for the intended use, and the limitation is documented in the module and the README.

**3. `inspect container` is ZIP only.** It reuses `cadmpeg-container::ArchiveSnapshot` and adds what the existing summary does not have: physical offsets that feed straight into `inspect hex`. OLE/CFB streams are sector-scattered, so a single "offset" is not meaningful, and the reader in `cadmpeg-codec-sldprt::compound` is `pub(crate)`. Non-ZIP families stay with `cadmpeg inspect FILE`, and the error says so. *Confidence: high* — exposing the CFB reader would be a codec-crate API change out of scope here.

**4. `LayoutError` is an enum, not a string.** Tests assert on variants rather than message substrings, so rewording an error does not break a test.

**5. No new external dependencies.** `memchr` (search anchoring) and `thiserror` (`LayoutError`) are added to the CLI manifest; both are existing workspace dependencies already in `Cargo.lock`.

## Testing

49 unit tests in the new modules plus 16 CLI integration tests in `crates/cadmpeg/tests/inspect_bytes.rs` (a new file, to avoid conflicting with concurrent work in `cli.rs`). Every fixture is a byte array built in test code, and expected values are derived from the construction — hand-written bit patterns such as `0x3ff8_0000_0000_0000` for `1.5`, not output pasted back from a run. Error paths are covered: malformed layout tokens, missing and forbidden byte-order suffixes, zero and non-numeric `bytesN`/`padN` counts, odd-length and mixed-wildcard hex patterns, offsets past end of file, and record runs that overrun.

## Known limitations and future work

- `find`, `strings`, `diff`, and `container` read the whole file into memory. `hex`, `read`, and `struct` seek and read a bounded window. A streaming or memory-mapped path for the whole-file commands is the obvious next step for very large `.prt` inputs.
- `container` reads the file before the resource-limit profile applies, so `--limits service` bounds the archive parse but not the initial read.
- No JSON output mode. The other `cadmpeg` commands take `--json`; these do not, because their output is meant to be read. Worth adding if anything starts scripting against them.
- No format-aware annotation. Deliberately out of scope: these are general byte tools, and auto-detecting record structures belongs in the codecs.
- `cargo clippy --workspace --all-targets` reports one pre-existing `cloned_ref_to_slice_refs` in `crates/cadmpeg-codec-sldprt/src/resolved_features.rs:14031`, in a lib-test target. The repo gate (`cargo clippy --workspace`, without `--all-targets`) does not check that target and is clean. Untouched by this branch.

## Gates

`cargo fmt --all --check`, `cargo clippy --workspace -- -D warnings -W missing-docs`, `cargo build --workspace`, and `cargo test-fast` all pass. Both commits went through the pre-commit hook; `--no-verify` was not used.


Signed-off-by: pcurve <y7t7jvn2dr@privaterelay.appleid.com>
