### PR TITLE
Make cadmpeg diff tolerance-aware, and promote the comparator out of the test harness

### DIFF
--- a/crates/cadmpeg-codec-core/Cargo.toml
+++ b/crates/cadmpeg-codec-core/Cargo.toml
@@ -18,16 +18,15 @@ schema = ["dep:schemars"]
 # `golden` builds the shared snapshot harness the codec crates' golden tests
 # use. It is off by default and enabled through a dev-dependency, because the
 # harness reads a repository checkout and a registry consumer cannot run it.
-golden = ["dep:serde_json"]
+# `compare`, which the harness compares through, is not gated: `cadmpeg-ir`
+# compares IR documents with it at run time.
+golden = []
 
 [dependencies]
 serde.workspace = true
 schemars = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
-thiserror.workspace = true
-
-[dev-dependencies]
 serde_json.workspace = true
+thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/crates/cadmpeg-codec-core/src/compare.rs
+++ b/crates/cadmpeg-codec-core/src/compare.rs
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tolerance-aware semantic comparison of decoded values.
+//!
+//! ## Why a tolerance exists
+//!
+//! Decoded geometry passes through `f64::cos`, `f64::sin`, and friends, which
+//! resolve to the platform's libm and are not bit-reproducible: glibc, the MSVC
+//! runtime, and Apple's libm disagree in the last one or two units in the last
+//! place. One conical face pins `origin.v` scaled by `cos(half_angle)`, which
+//! serializes as `1.802581857082682` on Linux and `1.8025818570826815` on
+//! Windows and macOS — two units in the last place apart, and identical to
+//! fourteen significant digits.
+//!
+//! Exact equality therefore reports a platform as a change. That makes it the
+//! wrong relation for any question of the form "do these two decodes describe
+//! the same model", whether the asker is a snapshot harness or a user running a
+//! semantic comparison over the same file decoded on two machines.
+//!
+//! ## Why `1e-12` relative with a floor of one
+//!
+//! Platform libm disagreement is a few units in the last place, near `1e-16`
+//! relative, so [`FLOAT_TOLERANCE`] leaves four decimal orders of headroom
+//! while still catching any change with physical meaning: at millimeter scale
+//! it admits a picometer. The tolerance applies to the larger of the two
+//! magnitudes, floored at one, so values below unit magnitude compare
+//! absolutely rather than demanding ever-finer agreement as they approach zero
+//! — a relative test against zero can never pass, and `0.0` against `1e-30` is
+//! agreement for every purpose this relation serves.
+//!
+//! ## Why integers stay exact
+//!
+//! Counts, indices, degrees, versions, and identifiers serialize as JSON
+//! integers. Not one of them passes through libm, and a change of one in any of
+//! them is a real change in the model. [`values_agree`] therefore admits a
+//! tolerance only when *both* sides are fractional; an integer pair, and a
+//! value that moved between integer and fractional form, compare exactly.
+//!
+//! ## Tolerant equality is not transitive
+//!
+//! `a` agreeing with `b` and `b` agreeing with `c` do not imply that `a` agrees
+//! with `c`: two steps of just under the tolerance sum to just over it. Every
+//! verdict this module produces is therefore strictly about the one pair it was
+//! given. Consequences:
+//!
+//! - The relation cannot back a hash, an equivalence class, a `BTreeMap` key,
+//!   or a deduplication pass, all of which need transitivity to be coherent.
+//! - A digest over tolerantly compared values is a bitwise fingerprint and
+//!   agrees only under exact equality, so no tolerance can rescue one.
+//! - Chaining comparisons through an intermediate proves nothing about the
+//!   endpoints. Compare the two values the question is actually about.
+
+use std::fmt::Write as _;
+
+use serde_json::Value;
+
+/// Relative tolerance for a fractional number in a semantic comparison.
+///
+/// Applied against the larger magnitude of the two values, with a floor of one
+/// so small values compare absolutely. See the module documentation for why
+/// this magnitude.
+pub const FLOAT_TOLERANCE: f64 = 1e-12;
+
+/// Whether two fractional numbers agree within [`FLOAT_TOLERANCE`] relative to
+/// the larger magnitude, with a floor of one so small values compare
+/// absolutely.
+///
+/// Exact equality short-circuits, so two infinities of the same sign agree. Any
+/// other non-finite pair disagrees: `NaN` is not equal to itself, and an
+/// infinity against a finite value has no meaningful difference to bound.
+#[must_use]
+pub fn floats_agree(left: f64, right: f64) -> bool {
+    if left == right {
+        return true;
+    }
+    if !left.is_finite() || !right.is_finite() {
+        return false;
+    }
+    let magnitude = left.abs().max(right.abs()).max(1.0);
+    (left - right).abs() <= FLOAT_TOLERANCE * magnitude
+}
+
+/// Compares two JSON values structurally, tolerating only last-place
+/// disagreement between two fractional numbers.
+///
+/// Object key sets, array lengths, strings, booleans, nulls, and integers must
+/// match exactly; a fractional pair may differ by up to [`FLOAT_TOLERANCE`]
+/// relative to the larger magnitude. The relation is not transitive; see the
+/// module documentation.
+///
+/// # Errors
+///
+/// Returns a description of the first disagreement, located by JSON path
+/// relative to the values passed in.
+pub fn values_agree(left: &Value, right: &Value) -> Result<(), String> {
+    let mut path = String::new();
+    walk(left, right, &mut path)
+}
+
+/// Walks two values in step, recording the path to the first disagreement.
+fn walk(left: &Value, right: &Value, path: &mut String) -> Result<(), String> {
+    match (left, right) {
+        (Value::Object(left_map), Value::Object(right_map)) => {
+            if let Some(key) = left_map.keys().find(|key| !right_map.contains_key(*key)) {
+                return Err(disagreement(
+                    path,
+                    &format!("left has key `{key}`, right does not"),
+                ));
+            }
+            if let Some(key) = right_map.keys().find(|key| !left_map.contains_key(*key)) {
+                return Err(disagreement(
+                    path,
+                    &format!("right has key `{key}`, left does not"),
+                ));
+            }
+            for (key, left_child) in left_map {
+                let restore = path.len();
+                path.push('.');
+                path.push_str(key);
+                walk(left_child, &right_map[key], path)?;
+                path.truncate(restore);
+            }
+            Ok(())
+        }
+        (Value::Array(left_items), Value::Array(right_items)) => {
+            if left_items.len() != right_items.len() {
+                return Err(disagreement(
+                    path,
+                    &format!(
+                        "left has {} item(s), right has {}",
+                        left_items.len(),
+                        right_items.len()
+                    ),
+                ));
+            }
+            for (index, (left_child, right_child)) in left_items.iter().zip(right_items).enumerate()
+            {
+                let restore = path.len();
+                write!(path, "[{index}]").expect("writing to a String cannot fail");
+                walk(left_child, right_child, path)?;
+                path.truncate(restore);
+            }
+            Ok(())
+        }
+        (Value::Number(left_number), Value::Number(right_number)) => {
+            // Only a pair of fractional numbers can carry platform libm
+            // disagreement. Counts, indices, and versions serialize as integers
+            // and must match exactly, as must a value that changed between an
+            // integer and a fractional form.
+            let agree = match (left_number.as_f64(), right_number.as_f64()) {
+                (Some(left_float), Some(right_float))
+                    if left_number.is_f64() && right_number.is_f64() =>
+                {
+                    floats_agree(left_float, right_float)
+                }
+                _ => left_number == right_number,
+            };
+            if agree {
+                Ok(())
+            } else {
+                Err(disagreement(
+                    path,
+                    &format!("left {left_number}, right {right_number}"),
+                ))
+            }
+        }
+        _ if left == right => Ok(()),
+        _ => Err(disagreement(
+            path,
+            &format!("left {}, right {}", truncate(left), truncate(right)),
+        )),
+    }
+}
+
+/// Renders one disagreement with the JSON path that located it.
+fn disagreement(path: &str, detail: &str) -> String {
+    let location = if path.is_empty() { "<root>" } else { path };
+    format!("at `{location}`: {detail}")
+}
+
+/// Renders a value for a failure message, bounded so a whole arena cannot land
+/// in a panic or a report.
+fn truncate(value: &Value) -> String {
+    let text = value.to_string();
+    if text.len() > 120 {
+        format!("{}…", &text[..120])
+    } else {
+        text
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{floats_agree, values_agree, FLOAT_TOLERANCE};
+
+    /// The two values one conical face produces on Linux against Windows and
+    /// macOS. Their difference is platform libm disagreement, not a change in
+    /// the model, so the comparison must accept it.
+    const LINUX_CONE_V: f64 = 1.802_581_857_082_682;
+    const WINDOWS_CONE_V: f64 = 1.802_581_857_082_681_5;
+
+    /// Parses two JSON texts and compares them.
+    fn agree(left: &str, right: &str) -> Result<(), String> {
+        let left = serde_json::from_str(left).expect("left test literal is JSON");
+        let right = serde_json::from_str(right).expect("right test literal is JSON");
+        values_agree(&left, &right)
+    }
+
+    #[test]
+    fn last_place_platform_disagreement_agrees() {
+        assert_ne!(
+            LINUX_CONE_V.to_bits(),
+            WINDOWS_CONE_V.to_bits(),
+            "the fixture values must differ, or this test proves nothing"
+        );
+        assert!(floats_agree(LINUX_CONE_V, WINDOWS_CONE_V));
+        let left = format!("{{\"v\": {LINUX_CONE_V:?}}}");
+        let right = format!("{{\"v\": {WINDOWS_CONE_V:?}}}");
+        assert_ne!(left, right);
+        assert!(agree(&left, &right).is_ok());
+    }
+
+    #[test]
+    fn drift_beyond_the_tolerance_disagrees() {
+        let moved = LINUX_CONE_V * (1.0 + 1000.0 * FLOAT_TOLERANCE);
+        assert!(!floats_agree(LINUX_CONE_V, moved));
+        let error = agree(
+            &format!("{{\"v\": {LINUX_CONE_V:?}}}"),
+            &format!("{{\"v\": {moved:?}}}"),
+        )
+        .expect_err("a change above the tolerance must be reported");
+        assert!(error.contains(".v"), "{error}");
+    }
+
+    #[test]
+    fn structure_and_strings_stay_exact() {
+        for (left, right, expected_path) in [
+            (r#"{"a": "x"}"#, r#"{"a": "y"}"#, ".a"),
+            (r#"{"a": true}"#, r#"{"a": false}"#, ".a"),
+            (r#"{"a": [1, 2]}"#, r#"{"a": [1, 2, 3]}"#, ".a"),
+            (r#"{"a": {"b": 1}}"#, r#"{"a": {"c": 1}}"#, ".a"),
+            (r#"{"a": 1}"#, r#"{"a": 2}"#, ".a"),
+            (r#"{"a": 1.5}"#, r#"{"a": null}"#, ".a"),
+        ] {
+            let error = agree(left, right).expect_err("an exact-match field must be reported");
+            assert!(error.contains(expected_path), "{left} vs {right}: {error}");
+        }
+    }
+
+    #[test]
+    fn an_integer_never_gets_a_tolerance() {
+        // An integer one apart is well inside the relative tolerance at this
+        // magnitude, and must still be reported.
+        let count = 1_000_000_000_000_000_i64;
+        assert!(
+            (1.0_f64) <= FLOAT_TOLERANCE * (count as f64),
+            "the magnitudes must make this a genuine test of integer exactness"
+        );
+        let error = agree(
+            &format!("{{\"n\": {count}}}"),
+            &format!("{{\"n\": {}}}", count + 1),
+        )
+        .expect_err("an integer field must never be tolerated");
+        assert!(error.contains(".n"), "{error}");
+    }
+
+    #[test]
+    fn an_integer_against_a_fractional_form_disagrees() {
+        let error = agree(r#"{"a": 1}"#, r#"{"a": 1.0}"#)
+            .expect_err("a change of numeric form must be reported");
+        assert!(error.contains(".a"), "{error}");
+    }
+
+    #[test]
+    fn a_nested_path_is_reported() {
+        let error = agree(
+            r#"{"ir": {"model": {"pcurves": [{"v": 1.0}, {"v": 2.0}]}}}"#,
+            r#"{"ir": {"model": {"pcurves": [{"v": 1.0}, {"v": 9.0}]}}}"#,
+        )
+        .expect_err("a moved value must be reported");
+        assert!(error.contains(".ir.model.pcurves[1].v"), "{error}");
+    }
+
+    #[test]
+    fn small_values_compare_absolutely() {
+        assert!(floats_agree(0.0, FLOAT_TOLERANCE / 2.0));
+        assert!(!floats_agree(0.0, FLOAT_TOLERANCE * 10.0));
+    }
+
+    #[test]
+    fn non_finite_values_agree_only_when_identical() {
+        assert!(floats_agree(f64::INFINITY, f64::INFINITY));
+        assert!(!floats_agree(f64::INFINITY, f64::NEG_INFINITY));
+        assert!(!floats_agree(f64::NAN, f64::NAN));
+        assert!(!floats_agree(f64::INFINITY, 0.0));
+    }
+}

--- a/crates/cadmpeg-codec-core/src/golden.rs
+++ b/crates/cadmpeg-codec-core/src/golden.rs
@@ -26,14 +26,15 @@
 //!
 //! A byte-exact comparison therefore reports a platform as a regression. That
 //! is the case the repository rule against comparing decoded doubles for exact
-//! equality already covers, so [`snapshots_agree`] compares parsed JSON with
-//! structure and strings exact and only fractional numbers tolerant. Byte
-//! equality remains the fast path, and the determinism check stays byte-exact
-//! because two runs in one process share one libm and must agree bit for bit.
+//! equality already covers, so [`snapshots_agree`] parses both sides and defers
+//! to [`crate::compare::values_agree`], which holds structure and strings exact
+//! and tolerates only fractional numbers. Byte equality remains the fast path,
+//! and the determinism check stays byte-exact because two runs in one process
+//! share one libm and must agree bit for bit.
 //!
-//! The tolerance hides drift below [`FLOAT_TOLERANCE`] relative magnitude. It
-//! does not make decode reproducible across platforms; it only stops the
-//! goldens from reporting that as codec drift.
+//! The tolerance hides drift below [`crate::compare::FLOAT_TOLERANCE`] relative
+//! magnitude. It does not make decode reproducible across platforms; it only
+//! stops the goldens from reporting that as codec drift.
 //!
 //! ## What this does not cover
 //!
@@ -51,16 +52,9 @@
 //!   compared values, so it cannot agree across platforms either. See
 //!   [`elide_digests`].
 
-use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
-/// Relative tolerance for a fractional number in a snapshot comparison.
-///
-/// Applied against the larger magnitude of the two values, with a floor of one
-/// so small values compare absolutely. Platform libm disagreement is a few
-/// units in the last place, near `1e-16` relative, so this leaves four decimal
-/// orders of headroom while still catching any change with physical meaning.
-pub const FLOAT_TOLERANCE: f64 = 1e-12;
+use crate::compare::values_agree;
 
 /// One snapshot branch: a subdirectory of `tests/golden` and the function that
 /// produces the text pinned there.
@@ -287,15 +281,14 @@ fn read_golden(path: &Path) -> std::io::Result<String> {
 /// disagreement in fractional numbers.
 ///
 /// Byte equality short-circuits. Otherwise both sides parse as JSON and compare
-/// structurally: object key sets, array lengths, strings, booleans, nulls, and
-/// integers must match exactly, and a fractional number may differ by up to
-/// [`FLOAT_TOLERANCE`] relative to the larger magnitude. Text that does not
+/// structurally through [`crate::compare::values_agree`]. Text that does not
 /// parse as JSON falls back to a line diff.
 ///
 /// # Errors
 ///
 /// Returns a description locating the first disagreement, by JSON path when
-/// both sides parsed and by line number otherwise.
+/// both sides parsed and by line number otherwise. A path-located message reads
+/// `left` for the golden and `right` for the fresh snapshot.
 pub fn snapshots_agree(expected: &str, actual: &str) -> Result<(), String> {
     if expected == actual {
         return Ok(());
@@ -309,129 +302,7 @@ pub fn snapshots_agree(expected: &str, actual: &str) -> Result<(), String> {
             "at line {line}\n    golden: {golden_line}\n    actual: {actual_line}"
         ));
     };
-    let mut path = String::new();
-    values_agree(&expected_value, &actual_value, &mut path)
-}
-
-/// Walks two parsed snapshots in step, recording the path to the first
-/// disagreement.
-fn values_agree(
-    expected: &serde_json::Value,
-    actual: &serde_json::Value,
-    path: &mut String,
-) -> Result<(), String> {
-    use serde_json::Value;
-    match (expected, actual) {
-        (Value::Object(expected_map), Value::Object(actual_map)) => {
-            if let Some(key) = expected_map
-                .keys()
-                .find(|key| !actual_map.contains_key(*key))
-            {
-                return Err(disagreement(
-                    path,
-                    &format!("golden has key `{key}`, snapshot does not"),
-                ));
-            }
-            if let Some(key) = actual_map
-                .keys()
-                .find(|key| !expected_map.contains_key(*key))
-            {
-                return Err(disagreement(
-                    path,
-                    &format!("snapshot has key `{key}`, golden does not"),
-                ));
-            }
-            for (key, expected_child) in expected_map {
-                let restore = path.len();
-                path.push('.');
-                path.push_str(key);
-                values_agree(expected_child, &actual_map[key], path)?;
-                path.truncate(restore);
-            }
-            Ok(())
-        }
-        (Value::Array(expected_items), Value::Array(actual_items)) => {
-            if expected_items.len() != actual_items.len() {
-                return Err(disagreement(
-                    path,
-                    &format!(
-                        "golden has {} item(s), snapshot has {}",
-                        expected_items.len(),
-                        actual_items.len()
-                    ),
-                ));
-            }
-            for (index, (expected_child, actual_child)) in
-                expected_items.iter().zip(actual_items).enumerate()
-            {
-                let restore = path.len();
-                write!(path, "[{index}]").expect("writing to a String cannot fail");
-                values_agree(expected_child, actual_child, path)?;
-                path.truncate(restore);
-            }
-            Ok(())
-        }
-        (Value::Number(expected_number), Value::Number(actual_number)) => {
-            // Only a pair of fractional numbers can carry platform libm
-            // disagreement. Counts, indices, and versions serialize as integers
-            // and must match exactly, as must a value that changed between an
-            // integer and a fractional form.
-            let tolerant = match (expected_number.as_f64(), actual_number.as_f64()) {
-                (Some(left), Some(right)) if expected_number.is_f64() && actual_number.is_f64() => {
-                    floats_agree(left, right)
-                }
-                _ => expected_number == actual_number,
-            };
-            if tolerant {
-                Ok(())
-            } else {
-                Err(disagreement(
-                    path,
-                    &format!("golden {expected_number}, snapshot {actual_number}"),
-                ))
-            }
-        }
-        _ if expected == actual => Ok(()),
-        _ => Err(disagreement(
-            path,
-            &format!(
-                "golden {}, snapshot {}",
-                truncate_value(expected),
-                truncate_value(actual)
-            ),
-        )),
-    }
-}
-
-/// Renders one disagreement with the JSON path that located it.
-fn disagreement(path: &str, detail: &str) -> String {
-    let location = if path.is_empty() { "<root>" } else { path };
-    format!("at `{location}`: {detail}")
-}
-
-/// Whether two fractional numbers agree within [`FLOAT_TOLERANCE`] relative to
-/// the larger magnitude, with a floor of one so small values compare
-/// absolutely.
-fn floats_agree(left: f64, right: f64) -> bool {
-    if left == right {
-        return true;
-    }
-    if !left.is_finite() || !right.is_finite() {
-        return false;
-    }
-    let magnitude = left.abs().max(right.abs()).max(1.0);
-    (left - right).abs() <= FLOAT_TOLERANCE * magnitude
-}
-
-/// Renders a value for a failure message, bounded so a whole arena cannot land
-/// in a panic.
-fn truncate_value(value: &serde_json::Value) -> String {
-    let text = value.to_string();
-    if text.len() > 120 {
-        format!("{}…", &text[..120])
-    } else {
-        text
-    }
+    values_agree(&expected_value, &actual_value)
 }
 
 /// First differing line, 1-based, with both sides truncated for readability.
@@ -500,7 +371,8 @@ pub fn snapshot_text(value: &serde_json::Value) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{floats_agree, snapshots_agree, FLOAT_TOLERANCE};
+    use super::snapshots_agree;
+    use crate::compare::FLOAT_TOLERANCE;
 
     /// The two values one `FreeCAD` conical face produces on Linux against
     /// Windows and macOS. Their difference is platform libm disagreement, not
@@ -508,65 +380,36 @@ mod tests {
     const LINUX_CONE_V: f64 = 1.802_581_857_082_682;
     const WINDOWS_CONE_V: f64 = 1.802_581_857_082_681_5;
 
+    // The comparator's own semantics are covered by `crate::compare`. What
+    // follows covers only what `snapshots_agree` adds on top: the byte-equal
+    // fast path, parsing both sides, and the line-diff fallback for text that is
+    // not JSON.
+
+    #[test]
+    fn byte_identical_text_agrees_without_parsing() {
+        assert!(snapshots_agree("not json at all\n", "not json at all\n").is_ok());
+    }
+
     #[test]
     fn last_place_platform_disagreement_agrees() {
-        assert_ne!(
-            LINUX_CONE_V.to_bits(),
-            WINDOWS_CONE_V.to_bits(),
-            "the fixture values must differ, or this test proves nothing"
-        );
-        assert!(floats_agree(LINUX_CONE_V, WINDOWS_CONE_V));
         let golden = format!("{{\"v\": {LINUX_CONE_V:?}}}");
         let snapshot = format!("{{\"v\": {WINDOWS_CONE_V:?}}}");
-        assert_ne!(golden, snapshot);
+        assert_ne!(
+            golden, snapshot,
+            "the texts must differ, or this test proves nothing"
+        );
         assert!(snapshots_agree(&golden, &snapshot).is_ok());
     }
 
     #[test]
     fn drift_beyond_the_tolerance_disagrees() {
         let moved = LINUX_CONE_V * (1.0 + 1000.0 * FLOAT_TOLERANCE);
-        assert!(!floats_agree(LINUX_CONE_V, moved));
         let error = snapshots_agree(
             &format!("{{\"v\": {LINUX_CONE_V:?}}}"),
             &format!("{{\"v\": {moved:?}}}"),
         )
         .expect_err("a change above the tolerance must be reported");
         assert!(error.contains(".v"), "{error}");
-    }
-
-    #[test]
-    fn structure_and_strings_stay_exact() {
-        for (golden, snapshot, expected_path) in [
-            (r#"{"a": "x"}"#, r#"{"a": "y"}"#, ".a"),
-            (r#"{"a": true}"#, r#"{"a": false}"#, ".a"),
-            (r#"{"a": [1, 2]}"#, r#"{"a": [1, 2, 3]}"#, ".a"),
-            (r#"{"a": {"b": 1}}"#, r#"{"a": {"c": 1}}"#, ".a"),
-            (r#"{"a": 1}"#, r#"{"a": 2}"#, ".a"),
-            (r#"{"a": 1.5}"#, r#"{"a": null}"#, ".a"),
-        ] {
-            let error = snapshots_agree(golden, snapshot)
-                .expect_err("an exact-match field must be reported");
-            assert!(
-                error.contains(expected_path),
-                "{golden} vs {snapshot}: {error}"
-            );
-        }
-    }
-
-    #[test]
-    fn a_nested_path_is_reported() {
-        let error = snapshots_agree(
-            r#"{"ir": {"model": {"pcurves": [{"v": 1.0}, {"v": 2.0}]}}}"#,
-            r#"{"ir": {"model": {"pcurves": [{"v": 1.0}, {"v": 9.0}]}}}"#,
-        )
-        .expect_err("a moved value must be reported");
-        assert!(error.contains(".ir.model.pcurves[1].v"), "{error}");
-    }
-
-    #[test]
-    fn small_values_compare_absolutely() {
-        assert!(floats_agree(0.0, FLOAT_TOLERANCE / 2.0));
-        assert!(!floats_agree(0.0, FLOAT_TOLERANCE * 10.0));
     }
 
     #[test]

--- a/crates/cadmpeg-codec-core/src/lib.rs
+++ b/crates/cadmpeg-codec-core/src/lib.rs
@@ -2,6 +2,7 @@
 //! Bounded byte decoding primitives shared by cadmpeg codecs.
 
 pub mod be;
+pub mod compare;
 pub mod container;
 pub mod cursor;
 pub mod decode;

--- a/crates/cadmpeg-fuzz/Cargo.lock
+++ b/crates/cadmpeg-fuzz/Cargo.lock
@@ -78,6 +78,7 @@ name = "cadmpeg-codec-core"
 version = "0.3.1"
 dependencies = [
  "serde",
+ "serde_json",
  "thiserror",
 ]
 

--- a/crates/cadmpeg-ir/src/diff.rs
+++ b/crates/cadmpeg-ir/src/diff.rs
@@ -1,7 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Structural comparison of IR documents.
+//!
+//! Numbers compare through [`cadmpeg_codec_core::compare`], so a coordinate that
+//! differs only in the last place — what the same file decoded under two
+//! platforms' libm produces — is not reported as a change, while an integer
+//! count, index, or degree that moved by one always is. That module states the
+//! tolerance and its caveats, including that the relation is not transitive:
+//! every verdict here concerns exactly the two documents passed in.
+//!
+//! The comparison covers units, tolerances, and every model and native arena. It
+//! does not cover [`crate::document::SourceMeta`], so the digest attributes
+//! recorded there — `semantic_sha256` and its neighbours — cannot make a diff
+//! report a difference. That is the only coherent treatment of a digest here: a
+//! digest is a bitwise fingerprint of values this module compares tolerantly, so
+//! two decodes that agree to fourteen significant digits hash differently and no
+//! tolerance can reconcile them. A caller that needs to compare source metadata
+//! must compare it directly and decide for itself which attributes are
+//! bit-reproducible.
 
 use std::collections::BTreeMap;
+
+use cadmpeg_codec_core::compare::{floats_agree, values_agree};
 
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
@@ -58,6 +77,12 @@ impl IrDiff {
     }
 }
 
+/// Top-level field names whose values do not agree, tolerating last-place
+/// disagreement in fractional numbers at any depth beneath a field.
+///
+/// A field present on one side and absent on the other always counts as
+/// differing, so an `Option` that gained or lost a value is reported even when
+/// the value would have agreed.
 fn differing_fields<T: Serialize>(left: &T, right: &T) -> Vec<String> {
     let (Ok(Value::Object(left)), Ok(Value::Object(right))) =
         (serde_json::to_value(left), serde_json::to_value(right))
@@ -68,7 +93,11 @@ fn differing_fields<T: Serialize>(left: &T, right: &T) -> Vec<String> {
         .chain(right.keys())
         .collect::<std::collections::BTreeSet<_>>()
         .into_iter()
-        .filter(|key| left.get(*key) != right.get(*key))
+        .filter(|key| match (left.get(*key), right.get(*key)) {
+            (Some(before), Some(after)) => values_agree(before, after).is_err(),
+            (None, None) => false,
+            _ => true,
+        })
         .cloned()
         .collect()
 }
@@ -100,9 +129,17 @@ where
         .iter()
         .filter_map(|(id, before)| {
             let after = right.get(id)?;
-            (*before != *after).then(|| ModifiedEntity {
+            // Exact equality is the fast path and skips serializing the pair.
+            // Anything else goes to the tolerant field comparison, which decides
+            // whether the entity moved at all: an empty field list means every
+            // difference was below the tolerance.
+            if *before == *after {
+                return None;
+            }
+            let fields = differing_fields(*before, *after);
+            (!fields.is_empty()).then(|| ModifiedEntity {
                 id: (*id).to_owned(),
-                fields: differing_fields(*before, *after),
+                fields,
             })
         })
         .collect();
@@ -163,12 +200,24 @@ fn diff_native_namespaces(left: &CadIr, right: &CadIr) -> Vec<ArenaDiff> {
         .collect()
 }
 
+/// Whether two tolerance declarations agree, each component within the
+/// comparator's tolerance.
+fn tolerances_agree(left: crate::units::Tolerances, right: crate::units::Tolerances) -> bool {
+    floats_agree(left.linear, right.linear) && floats_agree(left.angular, right.angular)
+}
+
 /// Compare units, tolerances, and every entity arena by stable entity ID.
+///
+/// Fractional numbers compare within the tolerance stated by
+/// [`cadmpeg_codec_core::compare`]; integers, strings, enums, and structure
+/// compare exactly.
 pub fn diff(left: &CadIr, right: &CadIr) -> IrDiff {
+    // `Units` carries only the `LengthUnit` enum, so exact comparison is the
+    // correct relation for it; there is no float to tolerate.
     let unit_change =
         (left.units != right.units).then(|| (left.units.clone(), right.units.clone()));
-    let tolerance_change =
-        (left.tolerances != right.tolerances).then_some((left.tolerances, right.tolerances));
+    let tolerance_change = (!tolerances_agree(left.tolerances, right.tolerances))
+        .then_some((left.tolerances, right.tolerances));
     let mut per_arena = diff_arenas(left, right);
     per_arena.extend(diff_native_namespaces(left, right));
     IrDiff {
@@ -224,6 +273,143 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    /// Modified entity IDs in one arena of a diff.
+    fn modified(result: &super::IrDiff, kind: &str) -> Vec<String> {
+        result
+            .per_arena
+            .iter()
+            .find(|arena| arena.kind == kind)
+            .expect("every model arena appears in every diff")
+            .modified
+            .iter()
+            .map(|entity| entity.id.clone())
+            .collect()
+    }
+
+    /// Index of a point whose `x` is at unit magnitude or above, so a relative
+    /// perturbation of it is a real perturbation. A zero coordinate would make
+    /// either direction of these tests vacuous.
+    fn scaled_point(ir: &crate::CadIr) -> usize {
+        ir.model
+            .points
+            .iter()
+            .position(|point| point.position.x.abs() >= 1.0)
+            .expect("the cube fixture places points away from the origin")
+    }
+
+    /// A coordinate moved by one unit in the last place, which is what the same
+    /// file decoded under two platforms' libm produces.
+    #[test]
+    fn a_last_place_coordinate_move_is_not_a_difference() {
+        let left = unit_cube();
+        let mut right = left.clone();
+        let index = scaled_point(&left);
+        let before = right.model.points[index].position.x;
+        let after = f64::from_bits(before.to_bits() + 1);
+        assert_ne!(
+            before.to_bits(),
+            after.to_bits(),
+            "the coordinate must move, or this test proves nothing"
+        );
+        right.model.points[index].position.x = after;
+
+        assert_ne!(
+            serde_json::to_value(&left.model.points).unwrap(),
+            serde_json::to_value(&right.model.points).unwrap(),
+            "the serialized documents must differ, or exact equality would pass too"
+        );
+        let result = diff(&left, &right);
+        assert!(result.is_empty(), "{result:?}");
+    }
+
+    /// A tolerance declaration moved in the last place is the same declaration.
+    #[test]
+    fn a_last_place_tolerance_move_is_not_a_difference() {
+        let left = unit_cube();
+        let mut right = left.clone();
+        right.tolerances.linear = f64::from_bits(left.tolerances.linear.to_bits() + 1);
+        assert!(diff(&left, &right).is_empty());
+
+        right.tolerances.linear = left.tolerances.linear * 2.0;
+        assert!(diff(&left, &right).tolerance_change.is_some());
+    }
+
+    /// A change with physical meaning stays reported. A relative `1e-6` on a
+    /// coordinate is six orders above the tolerance.
+    #[test]
+    fn a_genuine_coordinate_change_is_still_reported() {
+        let left = unit_cube();
+        let mut right = left.clone();
+        let index = scaled_point(&left);
+        let point = &mut right.model.points[index].position;
+        point.x = point.x.mul_add(1e-6, point.x);
+
+        let result = diff(&left, &right);
+        assert!(!result.is_empty());
+        assert_eq!(
+            modified(&result, "points"),
+            [left.model.points[index].id.0.clone()]
+        );
+    }
+
+    /// An integer field is never tolerated, however large its magnitude and
+    /// however small the change relative to it.
+    #[test]
+    fn an_integer_field_differing_by_one_is_always_reported() {
+        use crate::geometry::{Curve, CurveGeometry, NurbsCurve};
+        use crate::ids::CurveId;
+        use crate::math::Point3;
+
+        let nurbs = |degree: u32| Curve {
+            id: CurveId("synthetic:tolerance:curve#nurbs".into()),
+            geometry: CurveGeometry::Nurbs(NurbsCurve {
+                degree,
+                knots: vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+                control_points: vec![
+                    Point3::new(0.0, 0.0, 0.0),
+                    Point3::new(1.0, 0.0, 0.0),
+                    Point3::new(2.0, 0.0, 0.0),
+                ],
+                weights: None,
+                periodic: false,
+            }),
+            source_object: None,
+        };
+
+        let mut left = unit_cube();
+        let mut right = left.clone();
+        left.model.curves.push(nurbs(2));
+        right.model.curves.push(nurbs(3));
+
+        let result = diff(&left, &right);
+        assert!(!result.is_empty());
+        assert_eq!(
+            modified(&result, "curves"),
+            ["synthetic:tolerance:curve#nurbs"]
+        );
+    }
+
+    /// `source` metadata, including the digest attributes, is outside what this
+    /// comparison covers, so a digest that cannot agree across platforms cannot
+    /// make a diff report a difference either.
+    #[test]
+    fn source_metadata_is_outside_the_comparison() {
+        let left = unit_cube();
+        let mut right = left.clone();
+        let source = right
+            .source
+            .get_or_insert_with(|| crate::document::SourceMeta {
+                format: "synthetic".into(),
+                ..Default::default()
+            });
+        source
+            .attributes
+            .insert("semantic_sha256".into(), "0".repeat(64));
+
+        assert_ne!(left.source, right.source);
+        assert!(diff(&left, &right).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## The defect

`cadmpeg diff` promises semantic comparison and delivered bitwise comparison. Decoded coordinates pass through `f64::cos` and friends, and glibc, the MSVC runtime, and Apple's libm disagree by one or two units in the last place. The same file decoded on Linux and on Windows therefore yields coordinates identical to fourteen significant digits, and `diff` reported every affected entity as modified and exited 1. A picometer of last-place noise is not a design change, so this was a false positive on the command's core promise.

The workspace's one relation that handles this correctly existed only inside a test harness, behind a feature flag, unreachable from product code.

Demonstration on two CADIR documents differing by exactly one unit in the last place on `model.bodies[1].transform[0][0]` (`1.0` against `1.0000000000000002`):

```
##### BEFORE (bf88bc798) #####
diff left.cadir.json vs right.cadir.json
  bodies: +0 -0 ~1
      modified: fcstd:model:body#DatumCoordinateSystem:… (transform)
exit=1

##### AFTER #####
diff left.cadir.json vs right.cadir.json
  identical
exit=0
```

Genuine changes to the same documents still exit 1 under the new binary: a relative `1e-6` on that coordinate reports `bodies … ~1`, and `surfaces[142].geometry.u_degree` moved from `1` to `2` reports `surfaces … ~1`.

## The promotion

`FLOAT_TOLERANCE`, `floats_agree`, and the recursive value walk move out of `cadmpeg-codec-core/src/golden.rs` into a new ungated `cadmpeg_codec_core::compare`. `golden.rs` keeps `snapshots_agree` and defers to `compare::values_agree`; the moved code is deleted there, not duplicated. There is exactly one implementation. `values_agree` now takes two values and owns its path buffer, so callers need no scratch argument. The comparator's tests move with it and gain integer-exactness and non-finite coverage; `golden.rs` keeps the tests for what it adds on top — the byte-equal fast path and the line-diff fallback for text that is not JSON. The six codec `golden_tests.rs` files are unchanged.

**Placement differs from the brief, which asked for `cadmpeg-ir`.** The dependency runs the other way: `cadmpeg-ir` depends on `cadmpeg-codec-core`, so a module in `cadmpeg-ir` is unreachable from `golden.rs`. Adding the edge, even as an optional dependency behind the `golden` feature, is rejected by cargo:

```
error: cyclic package dependency: package `cadmpeg-codec-core` depends on itself. Cycle:
package `cadmpeg-codec-core`
    ... which satisfies path dependency `cadmpeg-codec-core` of package `cadmpeg-ir`
    ... which satisfies path dependency `cadmpeg-ir` of package `cadmpeg-codec-core`
```

A dev-dependency would be allowed but is not usable, because `golden` is a library module rather than a test target. So the choice was `cadmpeg-codec-core` or two implementations, and two implementations is what this change exists to prevent. `cadmpeg-codec-core` is also the honest home: the comparator consumes `serde_json::Value` and knows nothing about IR types.

`serde_json` becomes a normal dependency of `cadmpeg-codec-core`; it was already an optional dependency of that crate under `golden` plus a dev-dependency, so no new dependency enters the workspace. The `golden` feature now gates only the filesystem harness.

## The three comparison sites

- `differing_fields` asks `values_agree` per top-level field instead of comparing serialized `Value`s with `!=`. A field present on one side only still counts as differing, so an `Option` that gained or lost a value is reported even when the value would have agreed.
- `arena` keeps exact equality as a fast path and otherwise lets the field comparison decide whether the entity moved at all. An empty field list means every difference was below the tolerance, so the entity is not reported as modified.
- `tolerances` compares its two `f64` components through `floats_agree`.
- `units` keeps exact comparison, which is correct: it carries only the `LengthUnit` enum and has no float to tolerate.

Integers stay exact at every depth. The comparator admits a tolerance only when both sides are fractional, so counts, indices, degrees, and versions compare exactly, as does a value that moved between integer and fractional form.

## The digest attributes

**The premise that motivated this question turns out to be false, and the finding is worth stating plainly: `cadmpeg_ir::diff` never compared `ir.source` at all.** It compares units, tolerances, model arenas, and native arenas. `SourceMeta`, which holds `semantic_sha256` and its neighbours, is not among them — on `main` and on this branch. Verified at the CLI: adding `semantic_sha256` to one side of a diff prints `identical` and exits 0 under both binaries.

So of the three options, (a) leave them exact and document the limitation is not a choice to implement but a state to pin. This branch adds a test asserting that `source` metadata is outside the comparison, and module documentation stating why: a digest is a bitwise fingerprint of values compared tolerantly, so two decodes agreeing to fourteen significant digits hash differently and no tolerance can reconcile them.

The alternatives were rejected:

- **(b) exclude a named digest-key list from diff** would add a hard-coded key list guarding a comparison that does not happen. Machinery that is never evaluated.
- **(c) report them under a separate classification** would require first *adding* source comparison, then immediately special-casing part of it. That is a feature request, not a defect fix, and it needs a decision about which source attributes are bit-reproducible that belongs to whoever wants source comparison.

There is a real gap adjacent to this: `diff` silently ignores every source attribute, not only the digests, so a change in `program_version` or `object_count` is invisible. That predates this branch and is out of scope; flagging it rather than fixing it here.

## Tolerant equality is not transitive

`a ⊜ b` and `b ⊜ c` do not imply `a ⊜ c`: two steps of just under the tolerance sum to just over it. The module documentation states this and its consequences — the relation cannot back a hash, an equivalence class, a map key, or a deduplication pass, and chaining through an intermediate proves nothing about the endpoints. Every verdict `diff` produces is strictly about the two documents passed in.

## Per-caller verdicts

| Caller | Verdict |
| --- | --- |
| `crates/cadmpeg/src/commands.rs:419` — CLI `diff` | Tolerant is correct, and is the point of the change. This is the user-facing semantic comparison whose exit code the defect corrupted. |
| `crates/cadmpeg-fuzz/fuzz_targets/ir_diff.rs:46` | Correct. Discards the result and fuzzes for panics; the comparator adds no panicking path. Builds clean. |
| `crates/cadmpeg-codec-f3d/src/tests.rs:300` | Correct and unaffected. Asserts one modified native record after changing `entity_suffix` to the integer `123456`, which integer exactness keeps reporting. |
| `crates/cadmpeg-ir/src/tests.rs:460` | Unaffected. Diffs a document against itself to enumerate arena kinds. |
| `crates/cadmpeg-ir/src/tests.rs:1762` | Unaffected. Asserts `added` on native arenas; presence is exact either way. |
| `crates/cadmpeg-ir/src/diff.rs` tests | Extended, see below. |

No other consumer exists: `IrDiff`, `ArenaDiff`, and `ModifiedEntity` are referenced only from `diff.rs` and the `lib.rs` re-export.

## Tests

Three directions pinned at the diff level, on synthetic IRs built from `examples::unit_cube` with expected values constructed rather than observed:

- a coordinate moved one unit in the last place produces an empty diff, with an assertion that the serialized documents genuinely differ first, so exact equality could not pass the same test;
- a relative `1e-6` on that same coordinate is still reported;
- a NURBS `degree` differing by one is always reported, and in the comparator's own tests at a magnitude where the relative tolerance would otherwise swallow a change of one;
- a tolerance declaration moved in the last place is not a change, doubled is;
- `source` metadata is outside the comparison.

Both tests that pick a coordinate select the first point at unit magnitude or above rather than index zero, because the cube fixture puts a point at the origin and perturbing `0.0` relatively is a no-op that would make the test vacuous in both directions.

## What did not change

`IR_VERSION` is untouched. No IR fields were added or moved. No golden moved — verified by running the full suite, not by reasoning about it: `git status crates/*/tests/golden/` is empty after `cargo test-fast`, which is expected since this changes comparison rather than serialization. `cadmpeg diff`'s output shape, report JSON, and exit-code contract are unchanged; only the verdict for last-place differences moves. The determinism check in `golden.rs` stays byte-exact, correctly — two runs in one process share one libm.

## Gate

`cargo fmt --all --check`, `cargo clippy` over the staged scope plus `cadmpeg-codec-core` with `-D warnings -W missing-docs`, `cargo test` over that scope `--all-targets` and `--doc`, `cargo check` on `cadmpeg-fuzz`, `cargo test -p cadmpeg-ir --features schema --lib`, and a full `cargo test-fast`: all pass, no new `#[allow]` needed.

Signed-off-by: Claude <irvel@enode.io>
