### PR TITLE
Judge catia neutral-model admissibility in canonical arena order

### DIFF
--- a/crates/cadmpeg-codec-catia/src/assemble.rs
+++ b/crates/cadmpeg-codec-catia/src/assemble.rs
@@ -54,7 +54,19 @@ pub(crate) fn annotate(
     annotations.exactness(id, exactness);
 }
 
-pub(crate) fn neutral_model_is_admissible(ir: &CadIr, pending_unknowns: &[UnknownRecord]) -> bool {
+/// Judge one candidate neutral model in the form the pipeline publishes it.
+///
+/// [`DecodeResult::new`](cadmpeg_ir::codec::DecodeResult::new) sorts every arena
+/// by entity id before a decoded document leaves the codec, so canonical arena
+/// order is a property of the pipeline rather than of any one emit pass. The
+/// candidate's model arenas are canonicalized here for the same reason: read in
+/// native traversal order, an otherwise complete model is rejected over an arena
+/// order the pipeline would have replaced.
+pub(crate) fn neutral_model_is_admissible(
+    ir: &mut CadIr,
+    pending_unknowns: &[UnknownRecord],
+) -> bool {
+    ir.model.finalize();
     cadmpeg_ir::validate::validate_with_additional_native_identities(
         ir,
         pending_unknowns.iter().map(|record| record.id.as_str()),
@@ -824,8 +836,8 @@ mod route_tests {
 
     #[test]
     fn neutral_model_admissibility_rejects_invalid_topology() {
-        let valid = CadIr::empty(Units::default());
-        assert!(neutral_model_is_admissible(&valid, &[]));
+        let mut valid = CadIr::empty(Units::default());
+        assert!(neutral_model_is_admissible(&mut valid, &[]));
 
         let mut invalid = CadIr::empty(Units::default());
         invalid.model.shells.push(Shell {
@@ -835,7 +847,54 @@ mod route_tests {
             wire_edges: Vec::new(),
             free_vertices: Vec::new(),
         });
-        assert!(!neutral_model_is_admissible(&invalid, &[]));
+        assert!(!neutral_model_is_admissible(&mut invalid, &[]));
+    }
+
+    /// Decimal object-id keys reach the gate in native traversal order, in which
+    /// `#10` follows `#9` but precedes it lexicographically. The gate must judge
+    /// that arena in the order the pipeline publishes it.
+    #[test]
+    fn neutral_model_admissibility_canonicalizes_arena_order() {
+        let mut ir = CadIr::empty(Units::default());
+        for key in [9_u32, 10] {
+            ir.model.curves.push(Curve {
+                id: CurveId(format!("catia:test:curve#{key}")),
+                geometry: CurveGeometry::Line {
+                    origin: Point3::new(0.0, 0.0, f64::from(key)),
+                    direction: Vector3::new(1.0, 0.0, 0.0),
+                },
+                source_object: None,
+            });
+        }
+        let unsorted = cadmpeg_ir::validate::validate_with_additional_native_identities(
+            &ir,
+            std::iter::empty(),
+            Vec::new(),
+        );
+        assert!(unsorted
+            .findings
+            .iter()
+            .any(|finding| finding.check == cadmpeg_ir::report::Check::ArenaOrder));
+
+        neutral_model_is_admissible(&mut ir, &[]);
+
+        assert_eq!(
+            ir.model
+                .curves
+                .iter()
+                .map(|curve| curve.id.0.clone())
+                .collect::<Vec<_>>(),
+            ["catia:test:curve#10", "catia:test:curve#9"]
+        );
+        let sorted = cadmpeg_ir::validate::validate_with_additional_native_identities(
+            &ir,
+            std::iter::empty(),
+            Vec::new(),
+        );
+        assert!(!sorted
+            .findings
+            .iter()
+            .any(|finding| finding.check == cadmpeg_ir::report::Check::ArenaOrder));
     }
 
     #[test]
@@ -868,7 +927,7 @@ mod route_tests {
             links: Vec::new(),
         }];
 
-        assert!(neutral_model_is_admissible(&ir, &unknowns));
+        assert!(neutral_model_is_admissible(&mut ir, &unknowns));
     }
 
     #[test]

--- a/crates/cadmpeg-codec-catia/src/families/b5/transfer/mod.rs
+++ b/crates/cadmpeg-codec-catia/src/families/b5/transfer/mod.rs
@@ -2812,6 +2812,209 @@ mod tests {
         ));
     }
 
+    /// One closed spherical component of a synthetic B5 graph. `face`, `loop_`,
+    /// `pcurve`, and `surface` are persistent object ids; `edges` names the three
+    /// edge object ids and `vertices` the three vertex-point rows.
+    struct SyntheticSphericalComponent {
+        face: u32,
+        loop_: u32,
+        pcurve: u32,
+        surface: u32,
+        edges: [u32; 3],
+        vertices: [usize; 3],
+        center: [f64; 3],
+    }
+
+    /// Build a B5 graph of independent closed spherical components. Each
+    /// component contributes one face carrying one three-member loop over a
+    /// single class-`1d` great-circle pcurve, as in
+    /// [`owned_sphere_class_1d_pcurve_enters_the_transfer_plan`].
+    fn synthetic_spherical_graph(components: &[SyntheticSphericalComponent]) -> B5Graph {
+        let chart_scale = 8.0;
+        let parameter_range = [0.0, 4.0 * std::f64::consts::PI];
+        let radius = 5.0;
+        let mut graph = B5Graph {
+            complete: true,
+            faces: Vec::new(),
+            face_records: BTreeMap::new(),
+            loops: BTreeMap::new(),
+            pcurves: BTreeMap::new(),
+            opaque_pcurves: BTreeMap::new(),
+            implicit_pcurves: BTreeMap::new(),
+            surfaces: BTreeMap::new(),
+            surface_aliases: BTreeMap::new(),
+            offset_surfaces: BTreeMap::new(),
+            extrusion_surfaces: BTreeMap::new(),
+            supported_surfaces: BTreeMap::new(),
+            parameter_incidences: BTreeMap::new(),
+            edges: BTreeMap::new(),
+            vertex_incidence_links: BTreeMap::new(),
+            vertex_points: Vec::new(),
+            logical_vertex_points: Vec::new(),
+            logical_vertex_refs: Vec::new(),
+            edge_vertices: BTreeMap::new(),
+            edge_parameter_incidences: BTreeMap::new(),
+            vertex_tolerances: BTreeMap::new(),
+            profiles: BTreeMap::new(),
+        };
+        for component in components {
+            graph.faces.push(B5Face {
+                object_id: component.face,
+                surface: component.surface,
+                loops: vec![component.loop_],
+                terminal_control: None,
+            });
+            graph.loops.insert(
+                component.loop_,
+                B5Loop {
+                    object_id: component.loop_,
+                    pcurves: vec![component.pcurve; 3],
+                    edges: component.edges.to_vec(),
+                    metadata: test_loop_metadata(3),
+                    surface: component.surface,
+                },
+            );
+            graph.opaque_pcurves.insert(
+                component.pcurve,
+                B5OpaquePcurve {
+                    object_id: component.pcurve,
+                    surface: component.surface,
+                    class: 0x1d,
+                    payload: Vec::new(),
+                    sphere_great_circle: Some(B5SphereGreatCirclePcurve {
+                        chart_bounds: [parameter_range, [0.0, std::f64::consts::TAU * chart_scale]],
+                        chart_shift: 0.0,
+                        chart_scale,
+                        slope: 0.0,
+                        phase: 0.0,
+                    }),
+                },
+            );
+            graph.surfaces.insert(
+                component.surface,
+                B5Surface::Sphere {
+                    center: component.center,
+                    direction_x: [1.0, 0.0, 0.0],
+                    direction_y: [0.0, 1.0, 0.0],
+                    axis: [0.0, 0.0, 1.0],
+                    radius,
+                    azimuth_range: [0.0, std::f64::consts::TAU],
+                    latitude_range: [-std::f64::consts::FRAC_PI_2, std::f64::consts::FRAC_PI_2],
+                    construction_radius: chart_scale,
+                    chart_origin: 0.0,
+                },
+            );
+            let points = [
+                [
+                    component.center[0] + radius,
+                    component.center[1],
+                    component.center[2],
+                ],
+                [
+                    component.center[0],
+                    component.center[1] + radius,
+                    component.center[2],
+                ],
+                [
+                    component.center[0] - radius,
+                    component.center[1],
+                    component.center[2],
+                ],
+            ];
+            for (row, point) in component.vertices.into_iter().zip(points) {
+                assert_eq!(row, graph.vertex_points.len(), "contiguous vertex rows");
+                graph.vertex_points.push(point);
+            }
+            for (position, edge) in component.edges.into_iter().enumerate() {
+                graph.edge_vertices.insert(
+                    edge,
+                    [
+                        component.vertices[position],
+                        component.vertices[(position + 1) % 3],
+                    ],
+                );
+            }
+        }
+        graph
+    }
+
+    /// B5 object ids carry an unpadded decimal key, so a face pair such as
+    /// `#9`/`#10` reaches the neutral model in ascending native order while
+    /// sorting the other way. The route must still produce an admissible model:
+    /// every cross-reference is an id string, so canonical arena order is a
+    /// property the pipeline restores rather than one the emit passes owe.
+    ///
+    /// Two ownership components put several arenas out of sorted order at once,
+    /// which one face cannot do. The container-level counterpart is
+    /// `tests::decode_float_packed_stream_transfers_topology_under_decimal_object_ids`.
+    #[test]
+    fn decimal_object_id_keys_transfer_to_an_admissible_model() {
+        let graph = synthetic_spherical_graph(&[
+            SyntheticSphericalComponent {
+                face: 9,
+                loop_: 29,
+                pcurve: 39,
+                surface: 2,
+                edges: [49, 50, 51],
+                vertices: [0, 1, 2],
+                center: [0.0, 0.0, 0.0],
+            },
+            SyntheticSphericalComponent {
+                face: 10,
+                loop_: 200,
+                pcurve: 300,
+                surface: 12,
+                edges: [400, 401, 402],
+                vertices: [3, 4, 5],
+                center: [100.0, 0.0, 0.0],
+            },
+        ]);
+
+        let mut ir = CadIr::empty(Units::default());
+        assert!(transfer(
+            &mut ir,
+            &mut AnnotationBuilder::new(),
+            graph,
+            &UnknownId("catia:payload:unknown#test".to_string()),
+        ));
+
+        // Native traversal order, which the arena-order check reads as unsorted.
+        assert_eq!(
+            ir.model
+                .faces
+                .iter()
+                .map(|face| face.id.0.as_str())
+                .collect::<Vec<_>>(),
+            ["catia:b5:face#9", "catia:b5:face#10"]
+        );
+        assert_eq!(ir.model.loops.len(), 2);
+        assert_eq!(ir.model.shells.len(), 2);
+        assert_eq!(ir.model.regions.len(), 2);
+        assert_eq!(ir.model.edges.len(), 6);
+        assert_eq!(ir.model.coedges.len(), 6);
+        assert_eq!(ir.model.vertices.len(), 6);
+        assert_eq!(ir.model.pcurves.len(), 2);
+        let unsorted_arenas = cadmpeg_ir::validate::validate(&ir, Vec::new())
+            .findings
+            .iter()
+            .filter(|finding| finding.check == cadmpeg_ir::report::Check::ArenaOrder)
+            .count();
+        assert!(
+            unsorted_arenas >= 6,
+            "one component cannot unsort this many arenas: {unsorted_arenas}"
+        );
+
+        assert!(crate::assemble::neutral_model_is_admissible(&mut ir, &[]));
+        assert_eq!(
+            ir.model
+                .faces
+                .iter()
+                .map(|face| face.id.0.as_str())
+                .collect::<Vec<_>>(),
+            ["catia:b5:face#10", "catia:b5:face#9"]
+        );
+    }
+
     #[test]
     fn torus_chart_lifts_meridians_and_latitudes_exactly() {
         let torus = B5Surface::Torus {

--- a/crates/cadmpeg-codec-catia/src/families/e5/decode.rs
+++ b/crates/cadmpeg-codec-catia/src/families/e5/decode.rs
@@ -144,7 +144,7 @@ pub(crate) fn try_decode_e5(
             &mut topology_annotations,
             topology,
             &surfaces,
-        ) && neutral_model_is_admissible(&topology_ir, &unknowns)
+        ) && neutral_model_is_admissible(&mut topology_ir, &unknowns)
     });
     if topology_transferred {
         ir = topology_ir;

--- a/crates/cadmpeg-codec-catia/src/families/freeform/mod.rs
+++ b/crates/cadmpeg-codec-catia/src/families/freeform/mod.rs
@@ -201,7 +201,7 @@ pub(crate) fn try_decode_freeform_surfaces(
             &mut topology_annotations,
             graph,
             &payload_id,
-        ) && neutral_model_is_admissible(&topology_ir, &unknowns)
+        ) && neutral_model_is_admissible(&mut topology_ir, &unknowns)
     });
     if topology_transferred {
         ir = topology_ir;

--- a/crates/cadmpeg-codec-catia/src/families/standard/decode.rs
+++ b/crates/cadmpeg-codec-catia/src/families/standard/decode.rs
@@ -1594,7 +1594,7 @@ pub(crate) fn try_decode_standard(
         &mut bound_standard_limit_curve_count,
     )
     .and_then(|()| {
-        neutral_model_is_admissible(&topology_ir, &unknowns)
+        neutral_model_is_admissible(&mut topology_ir, &unknowns)
             .then_some(())
             .ok_or(StandardTopologyFailure::InadmissibleNeutralModel)
     });

--- a/crates/cadmpeg-codec-catia/src/tests.rs
+++ b/crates/cadmpeg-codec-catia/src/tests.rs
@@ -5569,41 +5569,72 @@ pub(crate) fn b5_plane_payload(origin: [f64; 3]) -> Vec<u8> {
     plane
 }
 
+/// Encode one `0x18` object reference: the lead byte, then the id as a
+/// little-endian `u16`. See `wire::object_ref`.
+pub(crate) fn b5_object_ref(id: u32) -> [u8; 3] {
+    let [low, high] = u16::try_from(id)
+        .expect("object id fits a `0x18` reference")
+        .to_le_bytes();
+    [0x18, low, high]
+}
+
 pub(crate) fn b5_closed_triangle_stream() -> Vec<u8> {
-    let mut bytes = Vec::new();
-    let plane = b5_plane_payload([0.0; 3]);
-    append_b5_record(&mut bytes, 0x27, 100, &plane);
-    for (id, start, end) in [
+    b5_closed_triangle_stream_over_edges([300, 301, 302])
+}
+
+/// Build the closed-triangle object stream over caller-chosen edge object ids.
+///
+/// The `62` loop payload interleaves one pcurve reference and one edge reference
+/// per member and closes with the support-surface reference, so an edge id
+/// appears both in its `5e` allocation and in the loop member that uses it.
+pub(crate) fn b5_closed_triangle_stream_over_edges(edges: [u32; 3]) -> Vec<u8> {
+    const SURFACE: u32 = 100;
+    const LOOP: u32 = 400;
+    const FACE: u32 = 500;
+    let pcurves = [
         (200u32, [0.0, 0.0], [1.0, 0.0]),
         (201, [1.0, 0.0], [0.0, 1.0]),
         (202, [0.0, 1.0], [0.0, 0.0]),
-    ] {
+    ];
+
+    let mut bytes = Vec::new();
+    let plane = b5_plane_payload([0.0; 3]);
+    append_b5_record(&mut bytes, 0x27, SURFACE, &plane);
+    for (id, start, end) in pcurves {
         append_b5_record(
             &mut bytes,
             0x21,
             id,
-            &b5_linear_pcurve_payload(100, start, end),
+            &b5_linear_pcurve_payload(
+                u16::try_from(SURFACE).expect("support surface id fits a `u16`"),
+                start,
+                end,
+            ),
         );
     }
-    for id in [300u32, 301, 302] {
+    for id in edges {
         append_b5_record(&mut bytes, 0x5e, id, &[]);
     }
-    append_b5_record(
-        &mut bytes,
-        0x62,
-        400,
-        &[
-            0x87, 0x18, 200, 0, 0x18, 44, 1, 0x18, 201, 0, 0x18, 45, 1, 0x18, 202, 0, 0x18, 46, 1,
-            0x18, 100, 0, 0x83, 0x05, 0x05, 0x03, 0x01, 0x00, 0xff, 0xff, 0x01, 0x00, 0x01, 0x00,
-            0xff, 0xff, 0x01, 0x00, 0x01, 0x00, 0xff, 0xff, 0x01, 0x00, 0x01,
-        ],
-    );
-    append_b5_record(
-        &mut bytes,
-        0x5f,
-        500,
-        &[0x82, 0x18, 100, 0, 0x18, 144, 1, 0x05],
-    );
+
+    let mut loop_payload = vec![0x87];
+    for ((pcurve, _, _), edge) in pcurves.into_iter().zip(edges) {
+        loop_payload.extend_from_slice(&b5_object_ref(pcurve));
+        loop_payload.extend_from_slice(&b5_object_ref(edge));
+    }
+    loop_payload.extend_from_slice(&b5_object_ref(SURFACE));
+    loop_payload.extend_from_slice(&[0x83, 0x05, 0x05, 0x03]);
+    for _ in 0..pcurves.len() {
+        loop_payload.extend_from_slice(&[0x01, 0x00, 0xff, 0xff, 0x01, 0x00]);
+    }
+    loop_payload.push(0x01);
+    append_b5_record(&mut bytes, 0x62, LOOP, &loop_payload);
+
+    let mut face_payload = vec![0x82];
+    face_payload.extend_from_slice(&b5_object_ref(SURFACE));
+    face_payload.extend_from_slice(&b5_object_ref(LOOP));
+    face_payload.push(0x05);
+    append_b5_record(&mut bytes, 0x5f, FACE, &face_payload);
+
     for point in [[0.0f32, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]] {
         bytes.extend_from_slice(&[0x05, 0x08, 0x01]);
         for value in point {
@@ -20132,6 +20163,59 @@ fn decode_float_packed_stream_transfers_reference_closed_b5_topology() {
         .pcurves
         .iter()
         .all(|pcurve| pcurve.parameter_range == Some([0.0, 1.0])));
+    assert!(result.report.losses.iter().all(|loss| {
+        !matches!(
+            loss.code.category(),
+            cadmpeg_ir::report::LossCategory::Geometry | cadmpeg_ir::report::LossCategory::Topology
+        ) || loss.severity != cadmpeg_ir::report::Severity::Blocking
+    }));
+    let validation = cadmpeg_ir::validate::validate(&result.ir, Vec::new());
+    assert!(validation.is_ok(), "findings: {:?}", validation.findings);
+}
+
+/// A `b5 03` object id reaches the neutral model as an unpadded decimal key, so
+/// an edge triple such as `9`, `10`, `11` is emitted in ascending native order
+/// and sorts the other way. The route must still transfer the topology: a
+/// cross-reference is an id string, so arena order carries no reference
+/// semantics and the pipeline restores it.
+#[test]
+fn decode_float_packed_stream_transfers_topology_under_decimal_object_ids() {
+    let mut stream = b5_closed_triangle_stream_over_edges([9, 10, 11]);
+    append_b5_record(
+        &mut stream,
+        0x5e,
+        900,
+        &[
+            0x85, 0x81, 0x18, 0x85, 0x03, 0x18, 0x85, 0x03, 0x81, 0x81, 0x2a,
+        ],
+    );
+    append_b5_record(&mut stream, 0x5d, 901, &[0x81, 0x81, 0x04]);
+    crate::families::b5::graph::parse(&stream).expect("generated B5 topology");
+
+    let result = CatiaCodec
+        .decode(
+            &mut Cursor::new(object_main_catpart(&stream)),
+            &DecodeOptions::default(),
+        )
+        .expect("decode object-stream topology");
+
+    assert_eq!(result.ir.model.bodies.len(), 1);
+    assert_eq!(result.ir.model.faces.len(), 1);
+    assert_eq!(result.ir.model.loops.len(), 1);
+    assert_eq!(result.ir.model.coedges.len(), 3);
+    assert_eq!(result.ir.model.edges.len(), 3);
+    assert_eq!(result.ir.model.vertices.len(), 3);
+    assert_eq!(result.ir.model.pcurves.len(), 3);
+    assert_eq!(
+        result
+            .ir
+            .model
+            .edges
+            .iter()
+            .map(|edge| edge.id.0.as_str())
+            .collect::<Vec<_>>(),
+        ["catia:b5:edge#10", "catia:b5:edge#11", "catia:b5:edge#9"]
+    );
     assert!(result.report.losses.iter().all(|loss| {
         !matches!(
             loss.code.category(),

--- a/docs/formats/catia-open-items.md
+++ b/docs/formats/catia-open-items.md
@@ -716,13 +716,23 @@ This document uses ASD-STE100 Simplified Technical English. Record names, field 
 
 **Need.** We must know the delimiter grammar to separate adjacent surface records without a false marker match.
 
-### FV-09. Recoverable geometry in the object-stream path
+### FV-09. Object-stream loop membership and face resolution
 
-**Question.** Does a float-packed inner-no-FBB file carry B-rep geometry and topology a decoder can recover, or does the object-stream path admit only retained payloads?
+**Question.** Which `b5 03 62` loop allocations belong to the B-rep of an object-stream body, and what leaves an isolated face and its loop unresolved in a body whose other faces and loops resolve?
 
-**Known.** `catia.md` §11 "A nested-`V5_CFV2` file without a standard FBB spine" defines the object-stream grammar for this variant. The decoder transfers no geometry for it and says so with blocking `geometry_not_transferred` and `topology_not_transferred` losses. The decode snapshots committed before this tree had a reader disagree: they record a transferred surface for the cone input and a body with three edges, vertices, and procedural curves for the topology input. No commit between those snapshots and now changes this decode path, so the snapshots never matched the decoder they shipped with, and which side is right is unresolved.
+**Known.** `catia.md` §11 "A nested-`V5_CFV2` file without a standard FBB spine" defines the object-stream grammar for this variant. The variant carries recoverable B-rep geometry and topology: the decoder resolves the face, loop, coedge, edge, vertex, pcurve, and carrier graph of an object-stream body and transfers it. The transfer then prunes the elements whose references do not close. A small number of `62` allocations stay outside every face, and an isolated face-and-loop pair drops out of an otherwise resolved body, which leaves a residual blocking `topology_not_transferred` loss reporting a maximal reference-closed subset.
 
-**Need.** We must know whether the variant admits recoverable geometry, to tell a capability that regressed from geometry a decoder should never have emitted.
+**Need.** We must separate an unreferenced `62` allocation, which the membership rule admits, from a face whose loop reference fails to resolve, so that pruning cannot hide a decode defect behind a legal exclusion.
+
+**Note.** Until this tree the resolved graph did not reach the document at all. `assemble::neutral_model_is_admissible` judged the candidate model before `cadmpeg-ir` sorts each arena by entity id, and a `b5 03` id embeds an unpadded decimal `object_id`, so `catia:b5:face#10` preceded `catia:b5:face#9` and every topology arena failed the strict arena-order check together. The route then fell back to bare surface carriers. The gate now canonicalizes the candidate first, which is the form `DecodeResult::new` publishes. No identity change was needed: a cross-reference is an id string, so arena order carries no reference semantics.
+
+### FV-10. Float-packed fixture validity
+
+**Question.** What object-stream and analytic-carrier records must a synthesized float-packed inner-no-FBB input contain to be a valid specimen of the variant?
+
+**Known.** `catia.md` §6.7 "For `b5 03 29`, the 185-byte payload is" fixes the cone chart and §6.7 "`b5 03 5d` (vertex identity)" fixes the native vertex-identity chain. The committed golden fixtures for this variant satisfy neither and reach no geometry path, so no golden fixture exercises the object-stream transfer route. Route coverage is a programmatically synthesized object stream held in the crate's tests, which decodes end to end through the container.
+
+**Need.** We must know the minimum valid record set to synthesize golden fixtures that hold the object-stream route under snapshot.
 
 ## 8. Appearance
 


### PR DESCRIPTION
## The defect

Every catia decode route that reconstructs topology builds a candidate neutral model, validates it through `assemble::neutral_model_is_admissible`, and adopts it only when validation passes. The gate ran the validator over the candidate **in native traversal order**.

`DecodeResult::new` sorts every arena by entity id before a decoded document leaves the codec, so canonical arena order is a property of the pipeline, not of any emit pass. A `b5 03` object id embeds an unpadded decimal `object_id`, so `catia:b5:face#10` sorts before `catia:b5:face#9`. On a reference float-packed inner-no-FBB input, `families::b5::transfer` reconstructed a complete B-rep and then failed the strict arena-order check in **13 arenas at once** — `coedges`, `curves`, `edges`, `faces`, `loops`, `pcurves`, `points`, `procedural_curves`, `procedural_surfaces`, `regions`, `shells`, `surfaces`, `vertices` — with no other error of any kind. The route discarded the whole reconstruction and fell back to 211 bare surface carriers. Decode exited 0.

The same gate rejected the `standard` route's topology across essentially the whole reference set, for the same reason.

## The fix

`neutral_model_is_admissible` takes the candidate by mutable reference and canonicalizes its model arenas before validating, so the gate judges the candidate in the form the pipeline publishes. The three call sites in the `freeform`, `standard`, and `e5` routes pass their candidates by mutable reference.

**No id-scheme change was needed.** A cross-reference in this IR is an id string, so arena order carries no reference semantics: sorting an arena moves no reference and creates no dangling target. Zero-padding the decimal keys and sorting per-arena at emission — the shape an earlier investigation proposed — would have changed ~24 id sites to achieve what one `finalize` call achieves, and could not have made the arenas globally sorted anyway, because `catia:a5:`, `catia:a8:`, and `catia:b2:` carriers are appended to the same arenas after the b5 pass and sort ahead of `catia:b5:`.

## Verification on the reference set (54 inputs, counts only)

Per-file `validate` exit codes are **identical before and after** — no input moves from pass to fail.

**The b5 object-stream route.** Before: 0 topology entities, blocking `topology_not_transferred` for a graph that "did not close". After: `validate` reports **0 errors** with faces ~14.3k, loops ~15.1k, coedges/pcurves ~85.5k, edges ~85.3k, vertices/points ~85.2k, surfaces ~14.3k, curves ~85.5k, procedural curves ~83.5k, shells/regions ~14.2k, one body. `geometry_not_transferred` is gone. A narrower blocking `topology_not_transferred` remains, reporting the maximal reference-closed subset — that residual is FV-09, not this defect.

**Collateral effect on the standard route.** 41 of 54 inputs gain B-rep topology that no input had before (faces 0 → 4…827, edges 0 → 8…2489). Blocking `topology_not_transferred` clears on 41; `geometry_not_transferred` clears on 2.

**One regression, reported not fixed.** On one input, error count goes 1 → 17. The 16 new findings are `geometric_consistency` on standard coedges and match `bound_consolidated_standard_edge_count=16` exactly: `families::freeform::append_resolved_consolidated_surface_curves` binds a pcurve to a coedge without checking that it maps to the edge's vertex positions through the face surface. That stage runs *after* the gate and had never run on a real input, because no input had standard topology attached. It is a pre-existing latent defect newly exposed, and it does not change that input's exit code (it already failed on an unrelated `identity` error).

## Fixture status

No committed golden fixture reaches the b5 transfer route — `freeform_b5_topology.catpart` decodes to an entirely empty model with no object-stream coverage keys, so it never builds a b5 graph. Golden snapshots are unmoved by this change, which confirms no golden fixture's gate verdict changed.

An end-to-end synthetic CATPart already exists in-source (`b5_closed_triangle_stream` + `object_main_catpart`), but its object ids never straddle the decimal/lexicographic boundary, so it passed with and without the fix. Coverage added, all three failing without the fix and passing with it:

1. `neutral_model_admissibility_canonicalizes_arena_order` — the gate reorders a two-curve arena and clears the `ArenaOrder` finding.
2. `decimal_object_id_keys_transfer_to_an_admissible_model` — a synthesized two-component B5 graph under boundary-straddling ids runs the real `transfer` and is admissible; asserts at least six arenas are unsorted beforehand.
3. `decode_float_packed_stream_transfers_topology_under_decimal_object_ids` — a synthesized object stream over edge ids `9`, `10`, `11` decodes end to end through the container to a validating body (fails without the fix with 0 bodies).

`b5_closed_triangle_stream` is now parameterized by edge id through `b5_closed_triangle_stream_over_edges`, and `b5_object_ref` encodes a `0x18` reference so the loop payload is built from ids rather than hand-written bytes. The default ids reproduce the previous stream byte for byte.

## Docs

`catia-open-items.md`: FV-09 becomes the residual `b5 03 62` loop-membership and face-resolution question, with a `Note` recording the gate defect and what fixed it; new FV-10 records the absent golden fixture for the variant. `check-doc-anchors.py` passes. `catia.md` is unchanged — the format model did not move.

## What I did NOT do

- Did not change the validator or exempt catia from `ArenaOrder`.
- Did not change any entity id or add zero-padding — the evidence says neither is needed.
- Did not fix the `append_resolved_consolidated_surface_curves` binding defect described above.
- Did not add a golden `.catpart` fixture for the variant: authoring a valid specimen needs the `b5 03 5d` vertex-identity chain with `05` rosters and `06` incidences plus the FV-09 `62` membership rule, which is open. Route coverage is the in-source synthesized stream instead.
- Did not change `IR_VERSION` or regenerate any golden.