### PR TITLE
Cut CI wall-clock: runner job count, parallel gate jobs, no test debuginfo

### DIFF
--- a/.github/actions/cargo-job-count/action.yml
+++ b/.github/actions/cargo-job-count/action.yml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Match cargo's job count to the runner
+description: >
+  Export CARGO_BUILD_JOBS as the runner's core count, overriding the `jobs`
+  cap in .cargo/config.toml.
+
+runs:
+  using: composite
+  steps:
+    # `.cargo/config.toml` caps `jobs` at 6 so the final burst of very large
+    # concurrent links cannot push a developer machine past systemd-oomd's
+    # pressure threshold. Runners have 3 to 4 cores, where that cap is
+    # oversubscription rather than a limit: a full test build on 3 cores takes
+    # 287s at `jobs=3` and 476s at `jobs=6`. An environment variable beats the
+    # config file, so the cap keeps protecting the machine it was written for.
+    - name: Export CARGO_BUILD_JOBS
+      shell: bash
+      run: |
+        set -euo pipefail
+        # `nproc` on Linux and on the Windows runner's Git Bash; macOS has
+        # neither GNU coreutils nor `nproc`.
+        cores="$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)"
+        echo "runner reports ${cores} cores"
+        echo "CARGO_BUILD_JOBS=${cores}" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,22 @@ env:
   RUST_BACKTRACE: 1
   # Throwaway runners get nothing from incremental compilation or debuginfo;
   # both slow the build (debuginfo dominates MSVC link time in particular)
-  # and inflate the cargo cache.
+  # and inflate the cargo cache. `[profile.test]` in Cargo.toml sets `debug`
+  # explicitly, and a manifest value beats one inherited from `dev`, so the
+  # test profile needs its own variable to reach the test binaries. The cost
+  # is `file:line` in a CI backtrace; local runs keep it.
   CARGO_INCREMENTAL: 0
   CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
 
 jobs:
-  # Core gate: everything here must pass on stable.
-  check:
-    name: build / test / fmt / clippy (stable)
+  # The stable gate is three jobs rather than one long one. Clippy compiles the
+  # workspace through `clippy-driver`, whose artifacts are separate from the
+  # ones `cargo test` builds, so the work is additive and the steps only ever
+  # queued behind each other. Splitting makes the gate's wall-clock the slowest
+  # job instead of the sum of every step.
+  lint:
+    name: fmt / clippy (stable)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,8 +46,14 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Match cargo's job count to the runner
+        uses: ./.github/actions/cargo-job-count
+
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: stable
+          save-if: false
 
       - name: Specification reference check
         # Open-items documents cite the specification by section and paragraph
@@ -58,16 +72,59 @@ jobs:
         # style debt cannot hide behind crate-root cfg(test) mute lists.
         run: cargo clippy --workspace --all-targets
 
+  test:
+    name: test (stable)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Match cargo's job count to the runner
+        uses: ./.github/actions/cargo-job-count
+
+      - name: Cache cargo registry and target
+        # The only stable job that writes the shared cache. It builds the
+        # widest set of dependencies, and concurrent writers of one key make
+        # every loser log a conflict.
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: stable
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Unit and integration tests
         # Builds the full workspace (libs, bins, test harnesses) before
         # running, so a separate `cargo build` step would be redundant.
         run: cargo test-fast
 
       - name: Documentation tests
+        # Reuses the library rlibs the step above built; on its own job this
+        # would pay for the whole workspace again.
         run: cargo test --workspace --doc
 
+  features:
+    name: schema / fuzz (stable)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Match cargo's job count to the runner
+        uses: ./.github/actions/cargo-job-count
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: stable
+          save-if: false
+
       - name: Schema feature
-        # `schema` is off by default, so the steps above never build the
+        # `schema` is off by default, so the other jobs never build the
         # `JsonSchema` derives. This step is the only thing that compiles them
         # and runs the schema assertions, so a derive that stops matching its
         # type fails here rather than at release time.
@@ -79,7 +136,7 @@ jobs:
             --features cadmpeg-codec-core/schema,cadmpeg-codec-f3d/schema,cadmpeg-codec-catia/schema,cadmpeg-codec-sldprt/schema
 
       - name: Fuzz targets compile
-        # The fuzz crate declares its own `[workspace]`, so every step above
+        # The fuzz crate declares its own `[workspace]`, so every other job
         # skips it; a refactor that moves a codec's internals silently rots the
         # harnesses' imports. A stable `check` catches that drift without the
         # nightly toolchain `cargo fuzz build` needs.
@@ -105,8 +162,13 @@ jobs:
         with:
           toolchain: "1.88"
 
+      - name: Match cargo's job count to the runner
+        uses: ./.github/actions/cargo-job-count
+
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check
         run: cargo check --workspace
@@ -126,8 +188,13 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Match cargo's job count to the runner
+        uses: ./.github/actions/cargo-job-count
+
       - name: Cache cargo registry and target
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Unit and integration tests
         run: cargo test-fast

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -67,6 +67,9 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Match cargo's job count to the runner
+        uses: ./.github/actions/cargo-job-count
+
       - name: Set workspace version
         id: bump
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,8 @@ Lint levels live in `[workspace.lints]` in the root `Cargo.toml`, so `cargo clip
 
 Manifest levels apply to every cargo command, so a warning fails `cargo build` and `cargo test`, not only `cargo clippy`. Jobs on an unpinned toolchain set `RUSTFLAGS: -A warnings`, because lint sets differ between releases; the MSRV job is the only one.
 
+CI builds test binaries without debug information. A failure there reports a backtrace without `file:line`; run the failing test locally to get the line numbers back.
+
 The `JsonSchema` derives sit behind a `schema` feature that is off by default, because only `cadmpeg_ir::cadir_json_schema()` consumes them and building them costs 26% of `cadmpeg-ir`'s compile time. Run the schema side when you change IR or native record types:
 
 ```sh


### PR DESCRIPTION
## Summary

CI wall-clock grew about tenfold in three weeks. Test execution is not the cause: the suite runs in **20s on macOS** and **57s on Windows**, against **6m07s** and **8m21s** of compilation. Most of the growth is the codebase, which went from 71,561 to 765,956 lines in `crates/` over the same period. This PR removes the parts that are not.

### 1. The `jobs = 6` cap reaches CI

`.cargo/config.toml` caps compile fan-out at 6 so the final burst of very large concurrent links cannot push a developer machine past `systemd-oomd`'s pressure threshold. Runners have 3 to 4 cores, where that cap is oversubscription rather than a limit.

Controlled measurement, same tree, 3 cores via `taskset`, plenty of free RAM:

| | full test build |
|---|---|
| `jobs=3` | 287s |
| `jobs=6` | 476s (**+66%**) |

It landed in `e1d4daa3b` (07-31). Across that commit macOS went 4.7m → 10.3m while `crates/` grew 4.1% (603,748 → 628,448 lines).

A composite action now exports `CARGO_BUILD_JOBS` from the runner's core count. The config file keeps protecting the machine it was written for.

### 2. `CARGO_PROFILE_DEV_DEBUG: 0` never reached the test binaries

The workflow sets it with the comment "throwaway runners get nothing from debuginfo". The same commit added `[profile.test] debug = "line-tables-only"` to `Cargo.toml`, and a manifest value beats one inherited from `dev`.

| | core-minutes | artifacts |
|---|---|---|
| before | 17.2 | 4.4 GB |
| `CARGO_PROFILE_TEST_DEBUG: 0` | 15.0 (**−13%**) | 2.9 GB (−34%) |

The cost is `file:line` in a CI backtrace. No test reads a backtrace, `file!()`, or `line!()`; the full suite passes with the setting applied (5,295 tests). `CONTRIBUTING.md` records the trade-off.

### 3. The stable gate was five sequential compiles

```
Clippy                    115s
Unit and integration      278s
Documentation tests        10s
Schema feature             86s
Fuzz targets               51s     = 530s of the 587s job
```

Clippy compiles the workspace through `clippy-driver`, whose artifacts are separate from the ones `cargo test` builds. I checked that they do not evict each other — `cargo test --no-run` straight after `cargo clippy --all-targets` rebuilds 0 units in 5s — so this is additive work that was only ever queuing behind itself.

Split into `lint`, `test`, and `features`. Wall-clock becomes the slowest job instead of the sum.

### 4. Cache housekeeping (came out of the same investigation)

The repository's Actions cache is at **10.0 GB of the 10 GB limit across 74 entries**. Pull-request caches were evicting main's, which is why every restore logs `full match: false`. Cache writes are now restricted to `main`, and the three stable jobs share one key so the split does not triple the footprint. Only `test` writes it.

## Measured effect

Control is main's run on `bc2366f73`, the exact commit this branch is based on, with the old CI config. This branch changes only CI files, so the compiled tree is identical. This branch's run also had a **cold cache** (adding `CARGO_PROFILE_TEST_DEBUG` changes rust-cache's key, so it logged `No cache found` and built all 94 dependencies), which understates the gain.

| job | before (run 31005602575) | after (run 31029228615) | |
|---|---|---|---|
| build / test (macos-latest) | 13.5m | **9.3m** | −31% |
| build / test (windows-latest) | 10.3m | **7.9m** | −23% |
| stable gate | 9.4m (one job) | **4.4m** (`test` 4.4 / `lint` 2.8 / `features` 2.8) | −53% |
| MSRV check | 0.9m | 1.1m | cold cache |
| cargo audit | 0.4m | 0.4m | — |
| **pipeline wall-clock** | **13.5m** | **9.3m** | **−31%** |

All jobs pass. The runner core count is detected correctly: 3 on macOS, 4 on Linux and Windows.

One-time cost: the first run on `main` after this merges will also miss the cache and rebuild dependencies, then save under the new key.

## Deliberately not here

- **sccache.** Dependencies are 0.9 of 17.2 core-minutes; the other 95% is recompiled from scratch every run because `rust-cache` does not cache workspace crates and a fresh checkout invalidates a restored `target/` on mtime anyway. With a warm workspace, touching one leaf codec rebuilds 2 units in 77s against ~290s cold. That is the largest remaining win and it needs the cache budget sorted out first. Deferred by request.
- `fuzz-smoke.yml` — nightly, off the PR path, left alone.

## Checklist

- [x] Signed off — every commit (`git commit -s`).

Signed-off-by: pcurve <y7t7jvn2dr@privaterelay.appleid.com>

