### PR TITLE
Optimize STEP decode indexing and I/O paths

### DIFF
--- a/crates/cadmpeg-codec-step/src/parse.rs
+++ b/crates/cadmpeg-codec-step/src/parse.rs
@@ -319,47 +319,50 @@ impl Parser {
         if self.at != self.tokens.len() {
             return self.err("tokens after exchange terminator");
         }
-        let anchor_bindings = anchors
-            .iter()
-            .map(|anchor| (anchor.name.clone(), anchor.value.clone()))
-            .collect::<BTreeMap<_, _>>();
-        if anchor_bindings.len() != anchors.len() {
-            return self.err("duplicate anchor name");
-        }
-        let mut resolver = AnchorResolver::new(&anchor_bindings);
-        for anchor in &mut anchors {
-            anchor.value = resolver
-                .resolve_root(&anchor.value)
-                .map_err(|message| ParseError::Syntax { offset: 0, message })?;
-        }
-        for record in records.values_mut() {
-            for partial in &mut record.partials {
-                for value in &mut partial.parameters {
-                    *value =
-                        resolver
-                            .resolve_root(value)
-                            .map_err(|message| ParseError::Syntax {
-                                offset: record.span.start,
-                                message,
-                            })?;
+        if !anchors.is_empty() {
+            let anchor_bindings = anchors
+                .iter()
+                .map(|anchor| (anchor.name.clone(), anchor.value.clone()))
+                .collect::<BTreeMap<_, _>>();
+            if anchor_bindings.len() != anchors.len() {
+                return self.err("duplicate anchor name");
+            }
+            let mut resolver = AnchorResolver::new(&anchor_bindings);
+            for anchor in &mut anchors {
+                anchor.value = resolver
+                    .resolve_root(&anchor.value)
+                    .map_err(|message| ParseError::Syntax { offset: 0, message })?;
+            }
+            for record in records.values_mut() {
+                for partial in &mut record.partials {
+                    for value in &mut partial.parameters {
+                        *value =
+                            resolver
+                                .resolve_root(value)
+                                .map_err(|message| ParseError::Syntax {
+                                    offset: record.span.start,
+                                    message,
+                                })?;
+                    }
                 }
             }
         }
+        let mut refs = Vec::new();
         for anchor in &anchors {
-            let mut refs = Vec::new();
+            refs.clear();
             references(&anchor.value, &mut refs);
-            if refs.into_iter().any(|id| !records.contains_key(&id)) {
+            if refs.iter().any(|id| !records.contains_key(id)) {
                 return self.err("unresolved instance reference in anchor binding");
             }
         }
         for record in records.values() {
-            let mut refs = Vec::new();
+            refs.clear();
             for partial in &record.partials {
                 for value in &partial.parameters {
                     references(value, &mut refs);
                 }
             }
-            if refs.into_iter().any(|id| !records.contains_key(&id)) {
+            if refs.iter().any(|id| !records.contains_key(id)) {
                 return Self::err_at(record.span.start, "unresolved instance reference");
             }
         }
@@ -468,6 +471,9 @@ impl Parser {
     }
 
     fn value(&mut self) -> Result<Value, ParseError> {
+        if self.peek(&TokenKind::LParen) {
+            return Ok(Value::List(self.parameters()?));
+        }
         match self.next_kind()? {
             TokenKind::Instance(v) => Ok(Value::Reference(v)),
             TokenKind::Integer(v) => Ok(Value::Integer(v)),
@@ -478,10 +484,6 @@ impl Parser {
             TokenKind::Resource(v) => Ok(Value::Resource(v)),
             TokenKind::Omitted => Ok(Value::Omitted),
             TokenKind::Derived => Ok(Value::Derived),
-            TokenKind::LParen => {
-                self.at -= 1;
-                Ok(Value::List(self.parameters()?))
-            }
             TokenKind::Name(name) => {
                 let parameters = self.parameters()?;
                 if parameters.len() != 1 {
@@ -532,11 +534,11 @@ impl Parser {
         matches!(self.tokens.get(self.at).map(|t| &t.kind), Some(TokenKind::Name(name)) if name == expected)
     }
     fn next_kind(&mut self) -> Result<TokenKind, ParseError> {
-        let Some(token) = self.tokens.get(self.at) else {
+        let Some(token) = self.tokens.get_mut(self.at) else {
             return self.err("unexpected end of input");
         };
         self.at += 1;
-        Ok(token.kind.clone())
+        Ok(std::mem::replace(&mut token.kind, TokenKind::Omitted))
     }
     fn current_offset(&self) -> usize {
         self.tokens

--- a/crates/cadmpeg-codec-step/src/parse.rs
+++ b/crates/cadmpeg-codec-step/src/parse.rs
@@ -116,6 +116,24 @@ pub struct Exchange {
 #[derive(Debug, Default)]
 struct EntityIndex(OnceLock<HashMap<String, Vec<u64>>>);
 
+const EMPTY_ENTITY_IDS: &[u64] = &[];
+
+enum EntityIdIter<'a> {
+    Borrowed(std::slice::Iter<'a, u64>),
+    Owned(std::vec::IntoIter<u64>),
+}
+
+impl Iterator for EntityIdIter<'_> {
+    type Item = u64;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Borrowed(ids) => ids.next().copied(),
+            Self::Owned(ids) => ids.next(),
+        }
+    }
+}
+
 impl Clone for EntityIndex {
     fn clone(&self) -> Self {
         Self::default()
@@ -157,16 +175,31 @@ impl Exchange {
         &'a self,
         names: &[&str],
     ) -> impl Iterator<Item = (u64, &'a RawRecord)> {
-        let mut ids = names
-            .iter()
-            .filter_map(|name| self.entity_ids().get(*name))
-            .flatten()
-            .copied()
-            .collect::<Vec<_>>();
-        ids.sort_unstable();
-        ids.dedup();
-        ids.into_iter()
-            .filter_map(|id| self.records.get(&id).map(|record| (id, record)))
+        let ids = if let [name] = names {
+            let ids = self
+                .entity_ids()
+                .get(*name)
+                .map_or(EMPTY_ENTITY_IDS, Vec::as_slice);
+            EntityIdIter::Borrowed(ids.iter())
+        } else {
+            let capacity = names
+                .iter()
+                .filter_map(|name| self.entity_ids().get(*name))
+                .map(Vec::len)
+                .sum();
+            let mut ids = Vec::with_capacity(capacity);
+            ids.extend(
+                names
+                    .iter()
+                    .filter_map(|name| self.entity_ids().get(*name))
+                    .flatten()
+                    .copied(),
+            );
+            ids.sort_unstable();
+            ids.dedup();
+            EntityIdIter::Owned(ids.into_iter())
+        };
+        ids.filter_map(|id| self.records.get(&id).map(|record| (id, record)))
     }
 }
 

--- a/crates/cadmpeg-codec-step/src/reader/geometry.rs
+++ b/crates/cadmpeg-codec-step/src/reader/geometry.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! STEP representation units, placements, and geometry carriers.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{hash_map::Entry, BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 
 use cadmpeg_ir::document::CadIr;
 use cadmpeg_ir::eval::{nurbs_curve_parameter_domain, nurbs_curve_parameter_near_point};
@@ -20,6 +20,7 @@ use cadmpeg_ir::SourceObjectAssociation;
 
 use crate::parse::{Exchange, RawRecord, Value};
 
+use super::index::{step_instance_id, CarrierIndex};
 use super::opaque_record_id;
 
 pub(super) struct GeometryResult {
@@ -352,34 +353,34 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
     // STEP geometry is a graph, not an ordered stream. Resolve all deferred
     // curve constructors to a fixpoint so nested or forward references do not
     // disappear merely because their source record has a larger instance id.
-    let deferred_count = exchange
+    let mut carrier_index = CarrierIndex::from_ir(ir);
+    let deferred_ids = exchange
         .entities_any(&["TRIMMED_CURVE", "COMPOSITE_CURVE", "OFFSET_CURVE_3D"])
-        .count();
-    let mut decoded_curve_ids = ir
-        .model
-        .curves
-        .iter()
-        .map(|curve| curve.id.clone())
-        .collect::<BTreeSet<_>>();
-    for _ in 0..=deferred_count {
-        let mut progress = false;
-        for (id, record) in exchange.entities("TRIMMED_CURVE") {
-            let curve = CurveId(format!("step:data:curve#{id}"));
-            if decoded_curve_ids.contains(&curve) || record.partial("TRIMMED_CURVE").is_none() {
-                continue;
-            }
-            let Some(parameters) = entity_parameters(record, "TRIMMED_CURVE") else {
-                continue;
-            };
+        .map(|(id, _)| id)
+        .collect::<Vec<_>>();
+    let mut deferred_queue = VecDeque::from(deferred_ids);
+    let mut waiting_on = HashMap::<u64, Vec<u64>>::new();
+    while let Some(id) = deferred_queue.pop_front() {
+        if carrier_index.curves.contains_key(&id) {
+            continue;
+        }
+        let Some(record) = exchange.records.get(&id) else {
+            continue;
+        };
+        if let Some(parameters) = entity_parameters(record, "TRIMMED_CURVE") {
             let Some((basis_step, sense)) = trimmed_curve_attributes(parameters) else {
                 continue;
             };
+            if !carrier_index.curves.contains_key(&basis_step) {
+                waiting_on.entry(basis_step).or_default().push(id);
+                continue;
+            }
+            let curve = CurveId(format!("step:data:curve#{id}"));
             let basis = CurveId(format!("step:data:curve#{basis_step}"));
-            let Some(geometry) = ir
-                .model
+            let Some(geometry) = carrier_index
                 .curves
-                .iter()
-                .find(|candidate| candidate.id == basis)
+                .get(&basis_step)
+                .and_then(|index| ir.model.curves.get(*index))
                 .map(|candidate| candidate.geometry.clone())
             else {
                 continue;
@@ -408,6 +409,7 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
             let Some((start, end)) = start.zip(end) else {
                 continue;
             };
+            let curve_index = ir.model.curves.len();
             ir.model.curves.push(Curve {
                 id: curve.clone(),
                 geometry,
@@ -422,21 +424,30 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
                 },
                 cache_fit_tolerance: Some(0.0),
             });
-            decoded_curve_ids.insert(curve);
+            carrier_index.curves.insert(id, curve_index);
             typed.insert(id);
-            progress = true;
+            wake_deferred_dependents(id, &mut waiting_on, &mut deferred_queue);
+            continue;
         }
-        for (id, record) in exchange.entities("COMPOSITE_CURVE") {
-            let curve = CurveId(format!("step:data:curve#{id}"));
-            if decoded_curve_ids.contains(&curve) {
+        if record.partial("COMPOSITE_CURVE").is_some() {
+            let missing = composite_curve_dependencies(record, exchange)
+                .into_iter()
+                .filter(|dependency| !carrier_index.curves.contains_key(dependency))
+                .collect::<Vec<_>>();
+            if !missing.is_empty() {
+                for dependency in missing {
+                    waiting_on.entry(dependency).or_default().push(id);
+                }
                 continue;
             }
             let Some((segments, self_intersect)) =
-                composite_curve(record, exchange, &decoded_curve_ids)
+                composite_curve(record, exchange, &carrier_index)
             else {
                 continue;
             };
+            let curve = CurveId(format!("step:data:curve#{id}"));
             typed.extend(segments.iter().map(|(segment, _)| *segment));
+            let curve_index = ir.model.curves.len();
             ir.model.curves.push(Curve {
                 id: curve.clone(),
                 geometry: CurveGeometry::Composite {
@@ -445,100 +456,99 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
                 },
                 source_object: None,
             });
-            decoded_curve_ids.insert(curve);
+            carrier_index.curves.insert(id, curve_index);
             typed.insert(id);
-            progress = true;
+            wake_deferred_dependents(id, &mut waiting_on, &mut deferred_queue);
+            continue;
         }
-        for (id, record) in exchange.entities("OFFSET_CURVE_3D") {
-            let curve = CurveId(format!("step:data:curve#{id}"));
-            if decoded_curve_ids.contains(&curve) {
-                continue;
-            }
-            let Some(parameters) = entity_parameters(record, "OFFSET_CURVE_3D") else {
-                continue;
-            };
-            let source = parameters
-                .get(1)
-                .and_then(Value::reference)
-                .map(|source| CurveId(format!("step:data:curve#{source}")));
-            let distance = parameters.get(2).and_then(Value::number);
-            let self_intersect = parameters
-                .get(3)
-                .and_then(logical_value)
-                .map(StepLogical::into_option);
-            let reference_direction = parameters
-                .get(4)
-                .and_then(Value::reference)
-                .and_then(|direction| directions.get(&direction).copied());
-            let Some((source, distance, self_intersect, reference_direction)) = source
-                .zip(distance)
-                .zip(self_intersect)
-                .zip(reference_direction)
-                .map(|(((source, distance), self_intersect), direction)| {
-                    (source, distance, self_intersect, direction)
-                })
-            else {
-                continue;
-            };
-            let Some(geometry) = ir
-                .model
-                .curves
-                .iter()
-                .find(|candidate| candidate.id == source)
-                .map(|candidate| candidate.geometry.clone())
-            else {
-                continue;
-            };
-            ir.model.curves.push(Curve {
-                id: curve.clone(),
-                geometry,
-                source_object: None,
-            });
-            ir.model.procedural_curves.push(ProceduralCurve {
-                id: ProceduralCurveId(format!("step:construction:offset_curve#{id}")),
-                curve: curve.clone(),
-                definition: ProceduralCurveDefinition::SpatialOffset {
-                    source,
-                    distance: distance * scale,
-                    reference_direction,
-                    self_intersect,
-                },
-                cache_fit_tolerance: None,
-            });
-            decoded_curve_ids.insert(curve);
-            typed.insert(id);
-            progress = true;
+        let Some(parameters) = entity_parameters(record, "OFFSET_CURVE_3D") else {
+            continue;
+        };
+        let source_step = parameters.get(1).and_then(Value::reference);
+        let source = source_step.map(|source| CurveId(format!("step:data:curve#{source}")));
+        let distance = parameters.get(2).and_then(Value::number);
+        let self_intersect = parameters
+            .get(3)
+            .and_then(logical_value)
+            .map(StepLogical::into_option);
+        let reference_direction = parameters
+            .get(4)
+            .and_then(Value::reference)
+            .and_then(|direction| directions.get(&direction).copied());
+        let Some((source, distance, self_intersect, reference_direction)) = source
+            .zip(distance)
+            .zip(self_intersect)
+            .zip(reference_direction)
+            .map(|(((source, distance), self_intersect), direction)| {
+                (source, distance, self_intersect, direction)
+            })
+        else {
+            continue;
+        };
+        let Some(source_step) = source_step else {
+            continue;
+        };
+        if !carrier_index.curves.contains_key(&source_step) {
+            waiting_on.entry(source_step).or_default().push(id);
+            continue;
         }
-        if !progress {
-            break;
-        }
+        let Some(geometry) = carrier_index
+            .curves
+            .get(&source_step)
+            .and_then(|index| ir.model.curves.get(*index))
+            .map(|candidate| candidate.geometry.clone())
+        else {
+            continue;
+        };
+        let curve = CurveId(format!("step:data:curve#{id}"));
+        let curve_index = ir.model.curves.len();
+        ir.model.curves.push(Curve {
+            id: curve.clone(),
+            geometry,
+            source_object: None,
+        });
+        ir.model.procedural_curves.push(ProceduralCurve {
+            id: ProceduralCurveId(format!("step:construction:offset_curve#{id}")),
+            curve: curve.clone(),
+            definition: ProceduralCurveDefinition::SpatialOffset {
+                source,
+                distance: distance * scale,
+                reference_direction,
+                self_intersect,
+            },
+            cache_fit_tolerance: None,
+        });
+        carrier_index.curves.insert(id, curve_index);
+        typed.insert(id);
+        wake_deferred_dependents(id, &mut waiting_on, &mut deferred_queue);
     }
     for (id, _) in exchange.entities("TRIMMED_CURVE") {
-        if !decoded_curve_ids.contains(&CurveId(format!("step:data:curve#{id}"))) {
+        if !carrier_index.curves.contains_key(&id) {
             warnings.push(format!(
                 "TRIMMED_CURVE #{id} has invalid or unresolved basis/trim selectors"
             ));
         }
     }
     for (id, _) in exchange.entities("COMPOSITE_CURVE") {
-        if !decoded_curve_ids.contains(&CurveId(format!("step:data:curve#{id}"))) {
+        if !carrier_index.curves.contains_key(&id) {
             warnings.push(format!(
                 "COMPOSITE_CURVE #{id} has invalid, cyclic, or unresolved segments"
             ));
         }
     }
     for (id, _) in exchange.entities("OFFSET_CURVE_3D") {
-        if !decoded_curve_ids.contains(&CurveId(format!("step:data:curve#{id}"))) {
+        if !carrier_index.curves.contains_key(&id) {
             warnings.push(format!(
                 "OFFSET_CURVE_3D #{id} has invalid or unresolved basis parameters"
             ));
         }
     }
     for (id, _) in exchange.entities_any(&["TRIMMED_CURVE", "COMPOSITE_CURVE", "OFFSET_CURVE_3D"]) {
-        let curve = CurveId(format!("step:data:curve#{id}"));
-        if decoded_curve_ids.insert(curve.clone()) {
+        if let Entry::Vacant(entry) = carrier_index.curves.entry(id) {
+            let curve = CurveId(format!("step:data:curve#{id}"));
+            let curve_index = ir.model.curves.len();
             ir.model.curves.push(Curve {
-                id: curve,
+                id: curve.clone(),
                 geometry: CurveGeometry::Unknown {
                     record: exchange.records.get(&id).map(opaque_record_id),
                 },
@@ -547,19 +557,18 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
             warnings.push(format!(
                 "retained unresolved deferred curve #{id} as an unknown carrier"
             ));
+            entry.insert(curve_index);
         }
     }
     for (id, record) in exchange.entities_any(&["SURFACE_CURVE", "SEAM_CURVE"]) {
-        let Some(basis) =
-            surface_curve_basis(record).map(|basis| CurveId(format!("step:data:curve#{basis}")))
-        else {
+        let Some(basis) = surface_curve_basis(record) else {
             warnings.push(format!(
                 "{} #{id} has no decoded 3D curve",
                 record.simple_name().unwrap_or("SURFACE_CURVE")
             ));
             continue;
         };
-        if decoded_curve_ids.contains(&basis) {
+        if carrier_index.curves.contains_key(&basis) {
             typed.insert(id);
         } else {
             warnings.push(format!(
@@ -569,12 +578,6 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
         }
     }
 
-    let curve_ids = ir
-        .model
-        .curves
-        .iter()
-        .map(|curve| curve.id.clone())
-        .collect::<BTreeSet<_>>();
     for (id, record) in
         exchange.entities_any(&["SURFACE_OF_LINEAR_EXTRUSION", "SURFACE_OF_REVOLUTION"])
     {
@@ -582,8 +585,8 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
             Some("SURFACE_OF_LINEAR_EXTRUSION") => record
                 .parameter(1)
                 .and_then(Value::reference)
+                .filter(|curve| carrier_index.curves.contains_key(curve))
                 .map(|curve| CurveId(format!("step:data:curve#{curve}")))
-                .filter(|curve| curve_ids.contains(curve))
                 .zip(
                     record
                         .parameter(2)
@@ -599,8 +602,8 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
             Some("SURFACE_OF_REVOLUTION") => record
                 .parameter(1)
                 .and_then(Value::reference)
+                .filter(|curve| carrier_index.curves.contains_key(curve))
                 .map(|curve| CurveId(format!("step:data:curve#{curve}")))
-                .filter(|curve| curve_ids.contains(curve))
                 .zip(
                     record
                         .parameter(2)
@@ -741,12 +744,7 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
         }
     }
 
-    let decoded_curves = ir
-        .model
-        .curves
-        .iter()
-        .map(|curve| curve.id.clone())
-        .collect::<BTreeSet<_>>();
+    carrier_index = CarrierIndex::from_ir(ir);
     let deferred_surface_count = exchange
         .entities_any(&["CURVE_BOUNDED_SURFACE", "OFFSET_SURFACE"])
         .count();
@@ -754,21 +752,15 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
         let mut progress = false;
         for (id, record) in exchange.entities("CURVE_BOUNDED_SURFACE") {
             let surface = SurfaceId(format!("step:data:surface#{id}"));
-            if ir
-                .model
-                .surfaces
-                .iter()
-                .any(|candidate| candidate.id == surface)
-            {
+            if carrier_index.surfaces.contains_key(&id) {
                 continue;
             }
             let Some(parameters) = entity_parameters(record, "CURVE_BOUNDED_SURFACE") else {
                 continue;
             };
-            let support = parameters
-                .get(1)
-                .and_then(Value::reference)
-                .map(|support| SurfaceId(format!("step:data:surface#{support}")));
+            let support_step = parameters.get(1).and_then(Value::reference);
+            let support =
+                support_step.map(|support| SurfaceId(format!("step:data:surface#{support}")));
             let boundaries = parameters.get(2).and_then(references).map(|boundaries| {
                 boundaries
                     .into_iter()
@@ -776,15 +768,10 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
                     .collect::<Vec<_>>()
             });
             let implicit_outer = parameters.get(3).and_then(Value::logical);
-            let Some((support, boundaries, implicit_outer, geometry)) = support
-                .as_ref()
-                .and_then(|support| {
-                    ir.model
-                        .surfaces
-                        .iter()
-                        .find(|candidate| candidate.id == *support)
-                        .map(|candidate| candidate.geometry.clone())
-                })
+            let Some((support, boundaries, implicit_outer, geometry)) = support_step
+                .and_then(|support| carrier_index.surfaces.get(&support))
+                .and_then(|index| ir.model.surfaces.get(*index))
+                .map(|surface| surface.geometry.clone())
                 .zip(support)
                 .zip(boundaries)
                 .zip(implicit_outer)
@@ -793,13 +780,15 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
                 })
                 .filter(|(_, boundaries, _, _)| {
                     !boundaries.is_empty()
-                        && boundaries
-                            .iter()
-                            .all(|curve| decoded_curves.contains(curve))
+                        && boundaries.iter().all(|curve| {
+                            step_instance_id(&curve.0)
+                                .is_some_and(|id| carrier_index.curves.contains_key(&id))
+                        })
                 })
             else {
                 continue;
             };
+            let surface_index = ir.model.surfaces.len();
             ir.model.surfaces.push(Surface {
                 id: surface.clone(),
                 geometry,
@@ -816,17 +805,13 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
                 cache_fit_tolerance: None,
                 record_bounds: None,
             });
+            carrier_index.surfaces.insert(id, surface_index);
             typed.insert(id);
             progress = true;
         }
         for (id, record) in exchange.entities("OFFSET_SURFACE") {
             let surface = SurfaceId(format!("step:data:surface#{id}"));
-            if ir
-                .model
-                .surfaces
-                .iter()
-                .any(|candidate| candidate.id == surface)
-            {
+            if carrier_index.surfaces.contains_key(&id) {
                 continue;
             }
             let Some(parameters) = entity_parameters(record, "OFFSET_SURFACE") else {
@@ -835,6 +820,7 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
             let support = parameters
                 .get(1)
                 .and_then(Value::reference)
+                .filter(|support| carrier_index.surfaces.contains_key(support))
                 .map(|support| SurfaceId(format!("step:data:surface#{support}")));
             let distance = parameters.get(2).and_then(Value::number);
             let self_intersect = parameters
@@ -842,18 +828,13 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
                 .and_then(logical_value)
                 .map(StepLogical::into_option);
             let Some((support, distance, self_intersect)) = support
-                .filter(|support| {
-                    ir.model
-                        .surfaces
-                        .iter()
-                        .any(|candidate| candidate.id == *support)
-                })
                 .zip(distance)
                 .zip(self_intersect)
                 .map(|((support, distance), self_intersect)| (support, distance, self_intersect))
             else {
                 continue;
             };
+            let surface_index = ir.model.surfaces.len();
             ir.model.surfaces.push(Surface {
                 id: surface.clone(),
                 geometry: SurfaceGeometry::Unknown { record: None },
@@ -870,6 +851,7 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
                 cache_fit_tolerance: None,
                 record_bounds: None,
             });
+            carrier_index.surfaces.insert(id, surface_index);
             typed.insert(id);
             progress = true;
         }
@@ -878,43 +860,28 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
         }
     }
     for (id, _) in exchange.entities("CURVE_BOUNDED_SURFACE") {
-        if !ir
-            .model
-            .surfaces
-            .iter()
-            .any(|surface| surface.id == SurfaceId(format!("step:data:surface#{id}")))
-        {
+        if !carrier_index.surfaces.contains_key(&id) {
             warnings.push(format!(
                 "CURVE_BOUNDED_SURFACE #{id} has invalid or unresolved support/boundaries"
             ));
         }
     }
     for (id, _) in exchange.entities("OFFSET_SURFACE") {
-        if !ir
-            .model
-            .surfaces
-            .iter()
-            .any(|surface| surface.id == SurfaceId(format!("step:data:surface#{id}")))
-        {
+        if !carrier_index.surfaces.contains_key(&id) {
             warnings.push(format!(
                 "OFFSET_SURFACE #{id} has invalid or unresolved support parameters"
             ));
         }
     }
 
-    let mut decoded_curve_steps = ir
-        .model
-        .curves
-        .iter()
-        .filter_map(|curve| curve.id.0.rsplit('#').next()?.parse::<u64>().ok())
-        .collect::<BTreeSet<_>>();
     for record in exchange.entities("EDGE_CURVE").map(|(_, record)| record) {
         let Some(curve_step) = edge_curve_geometry_reference(record)
             .and_then(|curve| curve_carrier_record(curve, exchange))
         else {
             continue;
         };
-        if decoded_curve_steps.insert(curve_step) {
+        if let Entry::Vacant(entry) = carrier_index.curves.entry(curve_step) {
+            let curve_index = ir.model.curves.len();
             ir.model.curves.push(Curve {
                 id: CurveId(format!("step:data:curve#{curve_step}")),
                 geometry: CurveGeometry::Unknown {
@@ -925,17 +892,13 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
             warnings.push(format!(
                 "retained undecoded topology curve #{curve_step} as an unknown carrier"
             ));
+            entry.insert(curve_index);
         }
     }
-    let mut decoded_surface_steps = ir
-        .model
-        .surfaces
-        .iter()
-        .filter_map(|surface| surface.id.0.rsplit('#').next()?.parse::<u64>().ok())
-        .collect::<BTreeSet<_>>();
     for (id, _) in exchange.entities_any(&["CURVE_BOUNDED_SURFACE", "OFFSET_SURFACE"]) {
         let surface = SurfaceId(format!("step:data:surface#{id}"));
-        if decoded_surface_steps.insert(id) {
+        if let Entry::Vacant(entry) = carrier_index.surfaces.entry(id) {
+            let surface_index = ir.model.surfaces.len();
             ir.model.surfaces.push(Surface {
                 id: surface,
                 geometry: SurfaceGeometry::Unknown {
@@ -946,6 +909,7 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
             warnings.push(format!(
                 "retained unresolved deferred surface #{id} as an unknown carrier"
             ));
+            entry.insert(surface_index);
         }
     }
     for (&face_id, face) in &exchange.records {
@@ -959,7 +923,8 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
         let Some(surface_step) = face_surface_reference(face) else {
             continue;
         };
-        if decoded_surface_steps.insert(surface_step) {
+        if let Entry::Vacant(entry) = carrier_index.surfaces.entry(surface_step) {
+            let surface_index = ir.model.surfaces.len();
             ir.model.surfaces.push(Surface {
                 id: SurfaceId(format!("step:data:surface#{surface_step}")),
                 geometry: SurfaceGeometry::Unknown {
@@ -970,20 +935,15 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
             warnings.push(format!(
                 "retained undecoded face surface #{surface_step} from face #{face_id} as an unknown carrier"
             ));
+            entry.insert(surface_index);
         }
     }
-    let decoded_surfaces = ir
-        .model
-        .surfaces
-        .iter()
-        .map(|surface| surface.id.clone())
-        .collect::<BTreeSet<_>>();
     let planar_surface_ids = ir
         .model
         .surfaces
         .iter()
         .filter(|surface| matches!(surface.geometry, SurfaceGeometry::Plane { .. }))
-        .map(|surface| surface.id.clone())
+        .filter_map(|surface| step_instance_id(&surface.id.0))
         .collect::<BTreeSet<_>>();
     for (id, record) in exchange.entities("PCURVE") {
         if record.simple_name() != Some("PCURVE") {
@@ -1004,7 +964,6 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
-        let surface = surface_step.map(|surface| SurfaceId(format!("step:data:surface#{surface}")));
         let decoded = curve_steps
             .iter()
             .filter_map(|curve| {
@@ -1013,9 +972,8 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
                     .map(|decoded| (*curve, decoded))
             })
             .collect::<Vec<_>>();
-        let planar_surface = surface.clone();
-        let Some((curve_step, (geometry, geometry_records))) = surface
-            .filter(|surface| decoded_surfaces.contains(surface))
+        let Some((curve_step, (geometry, geometry_records))) = surface_step
+            .filter(|surface| carrier_index.surfaces.contains_key(surface))
             .and(match decoded.as_slice() {
                 [decoded] => Some(*decoded),
                 _ => None,
@@ -1025,8 +983,7 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
             continue;
         };
         let mut geometry = geometry.clone();
-        if planar_surface_ids.contains(planar_surface.as_ref().expect("surface was filtered above"))
-        {
+        if surface_step.is_some_and(|surface| planar_surface_ids.contains(&surface)) {
             scale_planar_pcurve_geometry(&mut geometry, scale);
         }
         ir.model.pcurves.push(Pcurve {
@@ -1054,12 +1011,7 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> GeometryResult {
             .and_then(logical_value)
             .and_then(StepLogical::into_option);
         let surface = SurfaceId(format!("step:data:surface#{id}"));
-        if !ir
-            .model
-            .surfaces
-            .iter()
-            .any(|candidate| candidate.id == surface)
-        {
+        if !carrier_index.surfaces.contains_key(&id) {
             continue;
         }
         let Some(select_outer) = select_outer else {
@@ -1123,29 +1075,12 @@ fn face_surface_reference(record: &RawRecord) -> Option<u64> {
         .next_back()
 }
 
-pub(super) fn associate_free_geometric_set_members(exchange: &Exchange, ir: &mut CadIr) {
-    let (owned_curves, owned_surfaces, owned_points) = topology_owned_carriers(ir);
-    let curve_indices = ir
-        .model
-        .curves
-        .iter()
-        .enumerate()
-        .map(|(index, curve)| (curve.id.0.clone(), index))
-        .collect::<BTreeMap<_, _>>();
-    let point_indices = ir
-        .model
-        .points
-        .iter()
-        .enumerate()
-        .map(|(index, point)| (point.id.0.clone(), index))
-        .collect::<BTreeMap<_, _>>();
-    let surface_indices = ir
-        .model
-        .surfaces
-        .iter()
-        .enumerate()
-        .map(|(index, surface)| (surface.id.0.clone(), index))
-        .collect::<BTreeMap<_, _>>();
+pub(super) fn associate_free_geometric_set_members(
+    exchange: &Exchange,
+    ir: &mut CadIr,
+    index: &CarrierIndex,
+    owned: &OwnedCarriers,
+) {
     for set in exchange.records.values() {
         if !matches!(
             set.simple_name(),
@@ -1175,24 +1110,24 @@ pub(super) fn associate_free_geometric_set_members(exchange: &Exchange, ir: &mut
                 layer: None,
                 instance_path: Vec::new(),
             };
-            if let Some(index) = curve_indices.get(&format!("step:data:curve#{member}")) {
-                if owned_curves.contains(&ir.model.curves[*index].id) {
+            if let Some(index) = index.curves.get(&member) {
+                if owned.curves.contains(index) {
                     continue;
                 }
                 ir.model.curves[*index]
                     .source_object
                     .get_or_insert_with(association);
             }
-            if let Some(index) = point_indices.get(&format!("step:data:point#{member}")) {
-                if owned_points.contains(&ir.model.points[*index].id) {
+            if let Some(index) = index.points.get(&member) {
+                if owned.points.contains(index) {
                     continue;
                 }
                 ir.model.points[*index]
                     .source_object
                     .get_or_insert_with(association);
             }
-            if let Some(index) = surface_indices.get(&format!("step:data:surface#{member}")) {
-                if owned_surfaces.contains(&ir.model.surfaces[*index].id) {
+            if let Some(index) = index.surfaces.get(&member) {
+                if owned.surfaces.contains(index) {
                     continue;
                 }
                 ir.model.surfaces[*index]
@@ -1208,29 +1143,12 @@ pub(super) fn associate_free_geometric_set_members(exchange: &Exchange, ir: &mut
 /// source owner for free geometry; without this association the generic IR
 /// reachability check would misclassify a valid standalone carrier as an
 /// orphan.
-pub(super) fn associate_free_representation_members(exchange: &Exchange, ir: &mut CadIr) {
-    let (owned_curves, owned_surfaces, owned_points) = topology_owned_carriers(ir);
-    let curve_indices = ir
-        .model
-        .curves
-        .iter()
-        .enumerate()
-        .map(|(index, curve)| (curve.id.0.clone(), index))
-        .collect::<BTreeMap<_, _>>();
-    let point_indices = ir
-        .model
-        .points
-        .iter()
-        .enumerate()
-        .map(|(index, point)| (point.id.0.clone(), index))
-        .collect::<BTreeMap<_, _>>();
-    let surface_indices = ir
-        .model
-        .surfaces
-        .iter()
-        .enumerate()
-        .map(|(index, surface)| (surface.id.0.clone(), index))
-        .collect::<BTreeMap<_, _>>();
+pub(super) fn associate_free_representation_members(
+    exchange: &Exchange,
+    ir: &mut CadIr,
+    index: &CarrierIndex,
+    owned: &OwnedCarriers,
+) {
     for representation in exchange.records.values().filter(|record| {
         record
             .partials
@@ -1259,22 +1177,22 @@ pub(super) fn associate_free_representation_members(exchange: &Exchange, ir: &mu
                 layer: None,
                 instance_path: Vec::new(),
             };
-            if let Some(index) = curve_indices.get(&format!("step:data:curve#{member}")) {
-                if !owned_curves.contains(&ir.model.curves[*index].id) {
+            if let Some(index) = index.curves.get(&member) {
+                if !owned.curves.contains(index) {
                     ir.model.curves[*index]
                         .source_object
                         .get_or_insert_with(association);
                 }
             }
-            if let Some(index) = point_indices.get(&format!("step:data:point#{member}")) {
-                if !owned_points.contains(&ir.model.points[*index].id) {
+            if let Some(index) = index.points.get(&member) {
+                if !owned.points.contains(index) {
                     ir.model.points[*index]
                         .source_object
                         .get_or_insert_with(association);
                 }
             }
-            if let Some(index) = surface_indices.get(&format!("step:data:surface#{member}")) {
-                if !owned_surfaces.contains(&ir.model.surfaces[*index].id) {
+            if let Some(index) = index.surfaces.get(&member) {
+                if !owned.surfaces.contains(index) {
                     ir.model.surfaces[*index]
                         .source_object
                         .get_or_insert_with(association);
@@ -1347,67 +1265,64 @@ fn surface_curve_basis(record: &RawRecord) -> Option<u64> {
         .and_then(|partial| partial.parameters.iter().find_map(Value::reference))
 }
 
-fn topology_owned_carriers(
-    ir: &CadIr,
-) -> (BTreeSet<CurveId>, BTreeSet<SurfaceId>, BTreeSet<PointId>) {
-    (
-        ir.model
-            .edges
-            .iter()
-            .filter_map(|edge| edge.curve.clone())
-            .chain(
-                ir.model
-                    .coedges
-                    .iter()
-                    .filter_map(|coedge| coedge.use_curve.clone()),
-            )
-            .collect(),
-        ir.model
-            .faces
-            .iter()
-            .map(|face| face.surface.clone())
-            .collect(),
-        ir.model
-            .vertices
-            .iter()
-            .map(|vertex| vertex.point.clone())
-            .collect(),
-    )
+pub(super) struct OwnedCarriers {
+    pub(super) curves: HashSet<usize>,
+    pub(super) surfaces: HashSet<usize>,
+    pub(super) points: HashSet<usize>,
 }
 
-pub(super) fn associate_topology_carriers(exchange: &Exchange, ir: &mut CadIr) {
-    let (owned_curves, owned_surfaces, owned_points) = topology_owned_carriers(ir);
-    let curve_indices = ir
+pub(super) fn topology_owned_carriers(ir: &CadIr, index: &CarrierIndex) -> OwnedCarriers {
+    let curves = ir
         .model
-        .curves
+        .edges
         .iter()
-        .enumerate()
-        .map(|(index, curve)| (curve.id.0.clone(), index))
-        .collect::<BTreeMap<_, _>>();
-    let surface_indices = ir
+        .filter_map(|edge| edge.curve.as_ref())
+        .chain(
+            ir.model
+                .coedges
+                .iter()
+                .filter_map(|coedge| coedge.use_curve.as_ref()),
+        )
+        .filter_map(|curve| step_instance_id(&curve.0))
+        .filter_map(|id| index.curves.get(&id).copied())
+        .collect();
+    let surfaces = ir
         .model
-        .surfaces
+        .faces
         .iter()
-        .enumerate()
-        .map(|(index, surface)| (surface.id.0.clone(), index))
-        .collect::<BTreeMap<_, _>>();
-    let point_indices = ir
+        .filter_map(|face| step_instance_id(&face.surface.0))
+        .filter_map(|id| index.surfaces.get(&id).copied())
+        .collect();
+    let points = ir
         .model
-        .points
+        .vertices
         .iter()
-        .enumerate()
-        .map(|(index, point)| (point.id.0.clone(), index))
-        .collect::<BTreeMap<_, _>>();
+        .filter_map(|vertex| step_instance_id(&vertex.point.0))
+        .filter_map(|id| index.points.get(&id).copied())
+        .collect();
+    OwnedCarriers {
+        curves,
+        surfaces,
+        points,
+    }
+}
+
+pub(super) fn associate_topology_carriers(
+    exchange: &Exchange,
+    ir: &mut CadIr,
+    index: &CarrierIndex,
+    owned: &OwnedCarriers,
+) {
     for (edge_id, edge) in exchange.entities("EDGE_CURVE") {
         let Some(curve_step) = edge_curve_geometry_reference(edge)
             .and_then(|curve| curve_carrier_record(curve, exchange))
         else {
             continue;
         };
-        let Some(index) = curve_indices.get(&format!("step:data:curve#{curve_step}")) else {
+        let Some(index) = index.curves.get(&curve_step) else {
             continue;
         };
-        if owned_curves.contains(&ir.model.curves[*index].id) {
+        if owned.curves.contains(index) {
             continue;
         }
         ir.model.curves[*index]
@@ -1426,10 +1341,10 @@ pub(super) fn associate_topology_carriers(exchange: &Exchange, ir: &mut CadIr) {
         let Some(surface_step) = face_surface_reference(face) else {
             continue;
         };
-        let Some(index) = surface_indices.get(&format!("step:data:surface#{surface_step}")) else {
+        let Some(index) = index.surfaces.get(&surface_step) else {
             continue;
         };
-        if owned_surfaces.contains(&ir.model.surfaces[*index].id) {
+        if owned.surfaces.contains(index) {
             continue;
         }
         ir.model.surfaces[*index]
@@ -1448,10 +1363,10 @@ pub(super) fn associate_topology_carriers(exchange: &Exchange, ir: &mut CadIr) {
         let Some(point_step) = vertex_point_reference(vertex) else {
             continue;
         };
-        let Some(index) = point_indices.get(&format!("step:data:point#{point_step}")) else {
+        let Some(index) = index.points.get(&point_step) else {
             continue;
         };
-        if owned_points.contains(&ir.model.points[*index].id) {
+        if owned.points.contains(index) {
             continue;
         }
         ir.model.points[*index]
@@ -1794,10 +1709,36 @@ fn cross(a: Vector3, b: Vector3) -> Vector3 {
 
 type CompositeCurveData = (Vec<(u64, CompositeCurveSegment)>, Option<bool>);
 
+fn wake_deferred_dependents(
+    id: u64,
+    waiting_on: &mut HashMap<u64, Vec<u64>>,
+    queue: &mut VecDeque<u64>,
+) {
+    if let Some(dependents) = waiting_on.remove(&id) {
+        queue.extend(dependents);
+    }
+}
+
+fn composite_curve_dependencies(record: &RawRecord, exchange: &Exchange) -> Vec<u64> {
+    let complex = record.partials.len() > 1;
+    let offset = usize::from(!complex);
+    record
+        .partial("COMPOSITE_CURVE")
+        .and_then(|composite| composite.parameters.get(offset))
+        .and_then(Value::list)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::reference)
+        .filter_map(|segment| exchange.records.get(&segment))
+        .filter(|segment| segment.simple_name() == Some("COMPOSITE_CURVE_SEGMENT"))
+        .filter_map(|segment| segment.parameter(2).and_then(Value::reference))
+        .collect()
+}
+
 fn composite_curve(
     record: &RawRecord,
     exchange: &Exchange,
-    decoded: &BTreeSet<CurveId>,
+    decoded: &CarrierIndex,
 ) -> Option<CompositeCurveData> {
     let complex = record.partials.len() > 1;
     let composite = record.partial("COMPOSITE_CURVE")?;
@@ -1822,14 +1763,11 @@ fn composite_curve(
                 }
                 _ => return None,
             };
-            let curve = CurveId(format!(
-                "step:data:curve#{}",
-                record.parameter(2)?.reference()?
-            ));
-            decoded.contains(&curve).then_some((
+            let curve_step = record.parameter(2)?.reference()?;
+            decoded.curves.contains_key(&curve_step).then_some((
                 id,
                 CompositeCurveSegment {
-                    curve,
+                    curve: CurveId(format!("step:data:curve#{curve_step}")),
                     same_sense: record.parameter(1)?.logical()?,
                     transition,
                 },

--- a/crates/cadmpeg-codec-step/src/reader/index.rs
+++ b/crates/cadmpeg-codec-step/src/reader/index.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Numeric indexes for STEP geometry carriers.
+
+use std::collections::HashMap;
+
+use cadmpeg_ir::document::CadIr;
+use cadmpeg_ir::math::Point3;
+
+/// Decode-local lookup tables for STEP carrier instance ids.
+pub(super) struct CarrierIndex {
+    pub(super) curves: HashMap<u64, usize>,
+    pub(super) points: HashMap<u64, usize>,
+    pub(super) surfaces: HashMap<u64, usize>,
+    point_positions: Vec<Point3>,
+}
+
+impl CarrierIndex {
+    pub(super) fn from_ir(ir: &CadIr) -> Self {
+        Self {
+            curves: ir
+                .model
+                .curves
+                .iter()
+                .enumerate()
+                .filter_map(|(index, curve)| step_instance_id(&curve.id.0).map(|id| (id, index)))
+                .collect(),
+            points: ir
+                .model
+                .points
+                .iter()
+                .enumerate()
+                .filter_map(|(index, point)| step_instance_id(&point.id.0).map(|id| (id, index)))
+                .collect(),
+            surfaces: ir
+                .model
+                .surfaces
+                .iter()
+                .enumerate()
+                .filter_map(|(index, surface)| {
+                    step_instance_id(&surface.id.0).map(|id| (id, index))
+                })
+                .collect(),
+            point_positions: ir.model.points.iter().map(|point| point.position).collect(),
+        }
+    }
+
+    pub(super) fn get(&self, id: u64) -> Option<&Point3> {
+        self.points
+            .get(&id)
+            .and_then(|index| self.point_positions.get(*index))
+    }
+
+    pub(super) fn contains_key(&self, id: u64) -> bool {
+        self.points.contains_key(&id)
+    }
+}
+
+/// Extract the numeric STEP instance id from a canonical IR identity.
+pub(super) fn step_instance_id(identity: &str) -> Option<u64> {
+    identity.rsplit_once('#')?.1.parse().ok()
+}

--- a/crates/cadmpeg-codec-step/src/reader/mod.rs
+++ b/crates/cadmpeg-codec-step/src/reader/mod.rs
@@ -16,6 +16,7 @@ use crate::parse::{self, Exchange, ParseDiagnostic, Value};
 
 mod dependencies;
 mod geometry;
+mod index;
 mod pmi;
 mod presentation;
 mod product;
@@ -109,10 +110,23 @@ fn decode_exchange_mode(
 
     let geometry = geometry::decode(exchange, &mut ir);
     let dependencies = dependencies::decode(exchange);
-    let topology = topology::decode(exchange, &mut ir);
-    geometry::associate_topology_carriers(exchange, &mut ir);
-    geometry::associate_free_geometric_set_members(exchange, &mut ir);
-    geometry::associate_free_representation_members(exchange, &mut ir);
+    let carrier_index = index::CarrierIndex::from_ir(&ir);
+    let topology = topology::decode(exchange, &mut ir, &carrier_index);
+    let carrier_index = index::CarrierIndex::from_ir(&ir);
+    let owned_carriers = geometry::topology_owned_carriers(&ir, &carrier_index);
+    geometry::associate_topology_carriers(exchange, &mut ir, &carrier_index, &owned_carriers);
+    geometry::associate_free_geometric_set_members(
+        exchange,
+        &mut ir,
+        &carrier_index,
+        &owned_carriers,
+    );
+    geometry::associate_free_representation_members(
+        exchange,
+        &mut ir,
+        &carrier_index,
+        &owned_carriers,
+    );
     let product = product::decode(exchange, &geometry, &topology, &mut ir);
     let tessellation = tessellation::decode(exchange, &geometry, &topology, &mut ir);
     let pmi = pmi::decode(exchange, &geometry, &mut ir);

--- a/crates/cadmpeg-codec-step/src/reader/topology.rs
+++ b/crates/cadmpeg-codec-step/src/reader/topology.rs
@@ -18,6 +18,8 @@ use cadmpeg_ir::topology::{
 
 use crate::parse::{Exchange, RawRecord, Value};
 
+use super::index::CarrierIndex;
+
 pub(super) struct TopologyResult {
     pub typed_records: BTreeSet<u64>,
     pub warnings: Vec<String>,
@@ -53,7 +55,11 @@ pub(super) fn is_body_representation(record: &RawRecord) -> bool {
     .any(|name| has_type(record, name))
 }
 
-pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> TopologyResult {
+pub(super) fn decode(
+    exchange: &Exchange,
+    ir: &mut CadIr,
+    carrier_index: &CarrierIndex,
+) -> TopologyResult {
     let mut commit_session = CommitSession::new(ir);
     let mut result = TopologyResult {
         typed_records: BTreeSet::new(),
@@ -67,27 +73,7 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> TopologyResult {
     let vertices = vertex_defs(exchange);
     let edges = edge_defs(exchange);
     let oriented = oriented_defs(exchange);
-    let decoded_points = ir
-        .model
-        .points
-        .iter()
-        .map(|point| point.id.clone())
-        .collect::<BTreeSet<_>>();
-    let point_positions = ir
-        .model
-        .points
-        .iter()
-        .filter_map(|point| {
-            point
-                .id
-                .0
-                .rsplit_once('#')?
-                .1
-                .parse::<u64>()
-                .ok()
-                .map(|id| (id, point.position))
-        })
-        .collect::<BTreeMap<_, _>>();
+    let point_positions = carrier_index;
     for (&vertex_id, vertex) in &exchange.records {
         if !has_type(vertex, "VERTEX_POINT") {
             continue;
@@ -98,7 +84,7 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> TopologyResult {
             ));
             continue;
         };
-        if !decoded_points.contains(&PointId(format!("step:data:point#{point_id}"))) {
+        if !carrier_index.points.contains_key(&point_id) {
             result.warnings.push(format!(
                 "VERTEX_POINT #{vertex_id} has unresolved point carrier #{point_id}"
             ));
@@ -137,7 +123,7 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> TopologyResult {
             exchange,
             &vertices,
             &edges,
-            &point_positions,
+            point_positions,
             &mut result.warnings,
         );
         let mut committed = 0;
@@ -183,7 +169,7 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> TopologyResult {
             exchange,
             &vertices,
             &edges,
-            &point_positions,
+            point_positions,
             scope_root,
             &mut result.warnings,
         );
@@ -222,26 +208,6 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> TopologyResult {
             ));
         }
     }
-    let geometry_ids = GeometryIds {
-        points: ir
-            .model
-            .points
-            .iter()
-            .map(|point| point.id.0.clone())
-            .collect(),
-        curves: ir
-            .model
-            .curves
-            .iter()
-            .map(|curve| curve.id.0.clone())
-            .collect(),
-        surfaces: ir
-            .model
-            .surfaces
-            .iter()
-            .map(|surface| surface.id.0.clone())
-            .collect(),
-    };
     let decoded_pcurves = ir
         .model
         .pcurves
@@ -292,7 +258,7 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> TopologyResult {
             &edges,
             &oriented,
             &decoded_pcurves,
-            &point_positions,
+            point_positions,
             scope_root,
             &mut result.warnings,
         );
@@ -356,7 +322,7 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> TopologyResult {
         if record.simple_name() != Some("GEOMETRICALLY_BOUNDED_SURFACE_SHAPE_REPRESENTATION") {
             continue;
         }
-        let omitted = geometric_set_omissions(record, exchange, &geometry_ids);
+        let omitted = geometric_set_omissions(record, exchange, carrier_index);
         if !omitted.is_empty() {
             result.warnings.push(format!(
                 "GEOMETRICALLY_BOUNDED_SURFACE_SHAPE_REPRESENTATION #{id} omitted unsupported or unresolved member(s): {}",
@@ -368,13 +334,13 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> TopologyResult {
             ));
         }
         let Some(mut built) =
-            build_geometric_set(id, record, exchange, &geometry_ids, &mut result.warnings)
+            build_geometric_set(id, record, exchange, carrier_index, &mut result.warnings)
         else {
             if mark_standalone_geometric_set(
                 id,
                 record,
                 exchange,
-                &geometry_ids,
+                carrier_index,
                 &mut result.typed_records,
             ) {
                 continue;
@@ -405,7 +371,7 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> TopologyResult {
         ) {
             continue;
         }
-        let omitted = geometric_set_omissions(record, exchange, &geometry_ids);
+        let omitted = geometric_set_omissions(record, exchange, carrier_index);
         if !omitted.is_empty() {
             result.warnings.push(format!(
                 "{} #{id} omitted unsupported or unresolved member(s): {}",
@@ -421,7 +387,7 @@ pub(super) fn decode(exchange: &Exchange, ir: &mut CadIr) -> TopologyResult {
             id,
             record,
             exchange,
-            &geometry_ids,
+            carrier_index,
             &mut result.typed_records,
         );
     }
@@ -483,7 +449,7 @@ fn source_numeric_id(identity: &str, kind: &str) -> Option<u64> {
 fn geometric_set_omissions(
     representation: &RawRecord,
     exchange: &Exchange,
-    geometry_ids: &GeometryIds,
+    carrier_index: &CarrierIndex,
 ) -> Vec<u64> {
     let Some(set_ids) = representation.parameter(1).and_then(refs) else {
         return Vec::new();
@@ -494,15 +460,9 @@ fn geometric_set_omissions(
         .filter(|set| has_type(set, "GEOMETRIC_SET") || has_type(set, "GEOMETRIC_CURVE_SET"))
         .flat_map(|set| set.parameter(1).and_then(refs).unwrap_or_default())
         .filter(|member| {
-            !geometry_ids
-                .points
-                .contains(&format!("step:data:point#{member}"))
-                && !geometry_ids
-                    .curves
-                    .contains(&format!("step:data:curve#{member}"))
-                && !geometry_ids
-                    .surfaces
-                    .contains(&format!("step:data:surface#{member}"))
+            !carrier_index.points.contains_key(member)
+                && !carrier_index.curves.contains_key(member)
+                && !carrier_index.surfaces.contains_key(member)
         })
         .collect()
 }
@@ -555,7 +515,7 @@ fn build_wire(
     exchange: &Exchange,
     vdefs: &BTreeMap<u64, VertexDef>,
     edefs: &BTreeMap<u64, EdgeDef>,
-    point_positions: &BTreeMap<u64, Point3>,
+    point_positions: &CarrierIndex,
     warnings: &mut Vec<String>,
 ) -> BuildOutcome {
     let Some(model) = exchange.records.get(&id) else {
@@ -607,7 +567,7 @@ fn build_wire_set(
     exchange: &Exchange,
     vdefs: &BTreeMap<u64, VertexDef>,
     edefs: &BTreeMap<u64, EdgeDef>,
-    point_positions: &BTreeMap<u64, Point3>,
+    point_positions: &CarrierIndex,
     scoped: bool,
     warnings: &mut Vec<String>,
 ) -> Option<Built> {
@@ -660,7 +620,7 @@ fn build_wire_set(
     let mut built_vertices = Vec::new();
     for vertex_id in used_vertices {
         let vertex = vdefs.get(&vertex_id)?;
-        point_positions.get(&vertex.point)?;
+        point_positions.get(vertex.point)?;
         built_vertices.push(Vertex {
             id: VertexId(format!("step:data:vertex#{vertex_id}{vertex_suffix}")),
             point: PointId(format!("step:data:point#{}", vertex.point)),
@@ -710,7 +670,7 @@ fn build_shell_wire(
     exchange: &Exchange,
     vdefs: &BTreeMap<u64, VertexDef>,
     edefs: &BTreeMap<u64, EdgeDef>,
-    point_positions: &BTreeMap<u64, Point3>,
+    point_positions: &CarrierIndex,
     scope_root: bool,
     warnings: &mut Vec<String>,
 ) -> BuildOutcome {
@@ -764,7 +724,7 @@ fn build_shell_wire_set(
     exchange: &Exchange,
     vdefs: &BTreeMap<u64, VertexDef>,
     edefs: &BTreeMap<u64, EdgeDef>,
-    point_positions: &BTreeMap<u64, Point3>,
+    point_positions: &CarrierIndex,
     scoped: bool,
     scope_root: bool,
     warnings: &mut Vec<String>,
@@ -852,7 +812,7 @@ fn build_shell_wire_set(
         .into_iter()
         .map(|vertex_id| {
             let vertex = vdefs.get(&vertex_id)?;
-            point_positions.get(&vertex.point)?;
+            point_positions.get(vertex.point)?;
             Some(Vertex {
                 id: VertexId(format!("step:data:vertex#{vertex_id}{vertex_suffix}")),
                 point: PointId(format!("step:data:point#{}", vertex.point)),
@@ -905,7 +865,7 @@ fn mark_standalone_geometric_set(
     id: u64,
     representation: &RawRecord,
     exchange: &Exchange,
-    geometry_ids: &GeometryIds,
+    carrier_index: &CarrierIndex,
     typed: &mut BTreeSet<u64>,
 ) -> bool {
     let Some(set_ids) = representation.parameter(1).and_then(refs) else {
@@ -926,12 +886,9 @@ fn mark_standalone_geometric_set(
             continue;
         };
         let has_decoded_member = items.into_iter().any(|item| {
-            let point = format!("step:data:point#{item}");
-            let curve = format!("step:data:curve#{item}");
-            let surface = format!("step:data:surface#{item}");
-            geometry_ids.points.contains(&point)
-                || geometry_ids.curves.contains(&curve)
-                || geometry_ids.surfaces.contains(&surface)
+            carrier_index.points.contains_key(&item)
+                || carrier_index.curves.contains_key(&item)
+                || carrier_index.surfaces.contains_key(&item)
         });
         if has_decoded_member {
             typed.insert(set_id);
@@ -948,7 +905,7 @@ fn build_geometric_set(
     id: u64,
     representation: &RawRecord,
     exchange: &Exchange,
-    geometry_ids: &GeometryIds,
+    carrier_index: &CarrierIndex,
     warnings: &mut Vec<String>,
 ) -> Option<Built> {
     let set_ids = refs(representation.parameter(1)?)?;
@@ -976,7 +933,7 @@ fn build_geometric_set(
         typed.insert(set_id);
         for surface_step in items {
             let surface = SurfaceId(format!("step:data:surface#{surface_step}"));
-            if geometry_ids.surfaces.contains(surface.as_str()) {
+            if carrier_index.surfaces.contains_key(&surface_step) {
                 surfaces.push((surface_step, surface));
             }
         }
@@ -1031,12 +988,6 @@ fn build_geometric_set(
             visible: None,
         },
     )
-}
-
-struct GeometryIds {
-    points: BTreeSet<String>,
-    curves: BTreeSet<String>,
-    surfaces: BTreeSet<String>,
 }
 
 #[derive(Clone)]
@@ -1578,7 +1529,7 @@ fn build(
     edefs: &BTreeMap<u64, EdgeDef>,
     odefs: &BTreeMap<u64, OrientedDef>,
     decoded_pcurves: &BTreeSet<PcurveId>,
-    point_positions: &BTreeMap<u64, Point3>,
+    point_positions: &CarrierIndex,
     scope_root: bool,
     warnings: &mut Vec<String>,
 ) -> BuildOutcome {
@@ -1701,7 +1652,7 @@ fn build_one(
     edefs: &BTreeMap<u64, EdgeDef>,
     odefs: &BTreeMap<u64, OrientedDef>,
     decoded_pcurves: &BTreeSet<PcurveId>,
-    point_positions: &BTreeMap<u64, Point3>,
+    point_positions: &CarrierIndex,
     shell_steps: &[u64],
     bid: BodyId,
     rid: &RegionId,
@@ -1909,7 +1860,7 @@ fn build_one(
                     )?;
                     if !vdefs
                         .get(&vertex_step)
-                        .is_some_and(|vertex| point_positions.contains_key(&vertex.point))
+                        .is_some_and(|vertex| point_positions.contains_key(vertex.point))
                     {
                         note_failure(failure, vertex_step, "vertex point");
                         return None;
@@ -1966,7 +1917,7 @@ fn build_one(
                         || points.iter().collect::<BTreeSet<_>>().len() != points.len()
                         || points
                             .iter()
-                            .any(|point| !point_positions.contains_key(point))
+                            .any(|point| !point_positions.contains_key(*point))
                     {
                         note_failure(failure, loop_step, "poly loop point carrier");
                         return None;
@@ -2240,7 +2191,7 @@ fn build_one(
             "vertex definition",
         )?;
         require_carrier(
-            point_positions.get(&v.point),
+            point_positions.get(v.point),
             failure,
             v.point,
             "vertex point",
@@ -2254,7 +2205,7 @@ fn build_one(
     }
     for (shell_step, point_id) in poly_points {
         require_carrier(
-            point_positions.get(&point_id),
+            point_positions.get(point_id),
             failure,
             point_id,
             "poly vertex point",
@@ -2440,7 +2391,7 @@ fn implicit_face_points(
     vdefs: &BTreeMap<u64, VertexDef>,
     edefs: &BTreeMap<u64, EdgeDef>,
     odefs: &BTreeMap<u64, OrientedDef>,
-    point_positions: &BTreeMap<u64, Point3>,
+    point_positions: &CarrierIndex,
 ) -> Vec<Point3> {
     let mut points = Vec::new();
     for &bound_step in bounds {
@@ -2486,7 +2437,7 @@ fn implicit_face_points(
             let point_step = vdefs
                 .get(&vertex_or_point)
                 .map_or(vertex_or_point, |vertex| vertex.point);
-            let Some(point) = point_positions.get(&point_step).copied() else {
+            let Some(point) = point_positions.get(point_step).copied() else {
                 continue;
             };
             if !points.contains(&point) {
@@ -2503,7 +2454,7 @@ fn implicit_face_plane(
     vdefs: &BTreeMap<u64, VertexDef>,
     edefs: &BTreeMap<u64, EdgeDef>,
     odefs: &BTreeMap<u64, OrientedDef>,
-    point_positions: &BTreeMap<u64, Point3>,
+    point_positions: &CarrierIndex,
 ) -> Option<SurfaceGeometry> {
     let points = implicit_face_points(bounds, exchange, vdefs, edefs, odefs, point_positions);
     let origin = *points.first()?;

--- a/crates/cadmpeg-core/src/decode/context.rs
+++ b/crates/cadmpeg-core/src/decode/context.rs
@@ -2,6 +2,7 @@
 //! Decode state, decompression limits, and session lifecycle.
 
 use std::cell::Cell;
+use std::io::SeekFrom;
 
 use crate::{CodecError, ReadSeek};
 
@@ -41,23 +42,50 @@ impl<'a> DecodeContext<'a> {
     ) -> Result<(Self, View<'a>), CodecError> {
         let max = policy.limits.max_input_bytes;
         let cap = max.saturating_add(1);
-        let mut buffer: Vec<u8> = Vec::new();
-        let mut chunk = [0u8; 8192];
-        loop {
-            let remaining = cap.saturating_sub(buffer.len() as u64);
-            if remaining == 0 {
-                break;
-            }
-            let want = usize::try_from(remaining.min(chunk.len() as u64)).unwrap_or(chunk.len());
-            let read = reader.read(&mut chunk[..want]).map_err(CodecError::Io)?;
-            if read == 0 {
-                break;
+        let buffer = if let Ok(size) = reader
+            .seek(SeekFrom::End(0))
+            .and_then(|size| reader.rewind().map(|()| size))
+        {
+            let reserve = size.min(cap);
+            let reserve = usize::try_from(reserve)
+                .map_err(|_| root_error(ResourceFailure::AllocationFailed, max, reserve))?;
+            let mut buffer = Vec::new();
+            buffer
+                .try_reserve(reserve)
+                .map_err(|_| root_error(ResourceFailure::AllocationFailed, max, reserve as u64))?;
+            let mut chunk = vec![0u8; 256 * 1024].into_boxed_slice();
+            while (buffer.len() as u64) < cap {
+                let remaining = cap.saturating_sub(buffer.len() as u64);
+                let want =
+                    usize::try_from(remaining.min(chunk.len() as u64)).unwrap_or(chunk.len());
+                let read = reader.read(&mut chunk[..want]).map_err(CodecError::Io)?;
+                if read == 0 {
+                    break;
+                }
+                buffer.extend_from_slice(&chunk[..read]);
             }
             buffer
-                .try_reserve(read)
-                .map_err(|_| root_error(ResourceFailure::AllocationFailed, max, read as u64))?;
-            buffer.extend_from_slice(&chunk[..read]);
-        }
+        } else {
+            let mut buffer = Vec::new();
+            let mut chunk = [0u8; 8192];
+            loop {
+                let remaining = cap.saturating_sub(buffer.len() as u64);
+                if remaining == 0 {
+                    break;
+                }
+                let want =
+                    usize::try_from(remaining.min(chunk.len() as u64)).unwrap_or(chunk.len());
+                let read = reader.read(&mut chunk[..want]).map_err(CodecError::Io)?;
+                if read == 0 {
+                    break;
+                }
+                buffer
+                    .try_reserve(read)
+                    .map_err(|_| root_error(ResourceFailure::AllocationFailed, max, read as u64))?;
+                buffer.extend_from_slice(&chunk[..read]);
+            }
+            buffer
+        };
         if buffer.len() as u64 > max {
             return Err(root_error(
                 ResourceFailure::BudgetExceeded,

--- a/crates/cadmpeg-core/src/decode/tests.rs
+++ b/crates/cadmpeg-core/src/decode/tests.rs
@@ -2,6 +2,8 @@
 
 #![allow(clippy::unwrap_used)]
 
+use std::io::{self, Cursor, Read, Seek, SeekFrom};
+
 use crate::CodecError;
 
 use super::*;
@@ -22,6 +24,46 @@ fn root_limit_is_enforced() {
         Err(CodecError::ResourceLimit(limit))
             if limit.dimension == ResourceDimension::InputBytes
     ));
+}
+
+#[test]
+fn read_root_uses_sized_and_fallback_read_paths() {
+    let bytes = vec![0_u8; 32];
+    let policy = policy_with(|limits| limits.max_input_bytes = bytes.len() as u64);
+
+    let arena = DecodeArena::new();
+    let mut seekable = Cursor::new(bytes.clone());
+    let (_, root) = DecodeContext::read_root(&mut seekable, &arena, &policy).unwrap();
+    assert_eq!(root.window(), bytes.as_slice());
+
+    let arena = DecodeArena::new();
+    let mut fallback = Unseekable::new(bytes.clone());
+    let (_, root) = DecodeContext::read_root(&mut fallback, &arena, &policy).unwrap();
+    assert_eq!(root.window(), bytes.as_slice());
+}
+
+struct Unseekable {
+    input: Cursor<Vec<u8>>,
+}
+
+impl Unseekable {
+    fn new(bytes: Vec<u8>) -> Self {
+        Self {
+            input: Cursor::new(bytes),
+        }
+    }
+}
+
+impl Read for Unseekable {
+    fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
+        self.input.read(bytes)
+    }
+}
+
+impl Seek for Unseekable {
+    fn seek(&mut self, _: SeekFrom) -> io::Result<u64> {
+        Err(io::Error::other("seek unavailable"))
+    }
 }
 
 #[test]

--- a/crates/cadmpeg/src/commands.rs
+++ b/crates/cadmpeg/src/commands.rs
@@ -734,9 +734,10 @@ fn export_ir(
         );
         report
     } else {
-        let mut stdout = io::stdout().lock();
-        let report = plan.write_to(&mut stdout)?;
-        stdout.flush()?;
+        let stdout = io::stdout().lock();
+        let mut writer = BufWriter::with_capacity(64 * 1024, stdout);
+        let report = plan.write_to(&mut writer)?;
+        writer.flush()?;
         if format == Format::Cadir && decode_report.is_some() && source_fidelity.is_some() {
             eprintln!("note: CADIR written to stdout cannot carry its decode-fidelity sidecar");
         }

--- a/crates/cadmpeg/src/loader.rs
+++ b/crates/cadmpeg/src/loader.rs
@@ -20,7 +20,7 @@ pub const DETECTION_PREFIX_LEN: usize = 128 * 1024;
 pub fn read_prefix(path: &Path, n: usize) -> Result<Vec<u8>> {
     let mut f = File::open(path).with_context(|| format!("opening {}", path.display()))?;
     let mut buf = Vec::with_capacity(n);
-    let mut chunk = [0_u8; 16 * 1024];
+    let mut chunk = vec![0_u8; 64 * 1024].into_boxed_slice();
     while buf.len() < n {
         let remaining = n - buf.len();
         let chunk_len = remaining.min(chunk.len());


### PR DESCRIPTION
## Summary

- Buffer CADIR stdout export with a 64 KiB `BufWriter`.
- Remove STEP parser token-kind clones, skip the empty anchor walk, reuse reference-validation storage, and reduce `entities_any` allocation.
- Add a decode-local numeric `CarrierIndex`; use it for deferred curves, topology carriers, associations, and point lookup.
- Resolve deferred curves with a dependency work queue.
- Read seekable roots with one bounded reservation and 256 KiB chunks; retain the existing fallback path for unseekable readers; raise CLI detection reads to 64 KiB.
- No `cadmpeg-ir` or CADIR model-type changes. The only core change is the requested `DecodeContext::read_root` I/O path and its tests.

## Byte-identity evidence

Input: `arduino-due.step` (59,035,884 bytes).

Baseline and final output were both 163,914,948 bytes with SHA-256:

`d03283d3a4ca78e81c28a2c2718334dfdd9b883f5bd7c178e74c16be74705aaa`

The final output compared identical to the baseline with `cmp`, and `cadmpeg validate` exited 0.

| Phase | Wall | User | System | Peak RSS |
| --- | ---: | ---: | ---: | ---: |
| Clean baseline | 6.07 s | 5.15 s | 0.91 s | 1,349,728 KiB |
| Phase 1 | 5.94 s | 5.12 s | 0.82 s | 1,349,952 KiB |
| Phase 3 | 5.40 s | 4.51 s | 0.89 s | 1,287,784 KiB |
| Phase 4 queue | 5.16 s | 4.25 s | 0.90 s | 1,287,492 KiB |
| Phase 5 | 5.67 s | 4.76 s | 0.91 s | 1,287,768 KiB |
| Final phase 6 | 5.63 s | 4.67 s | 0.96 s | 1,287,380 KiB |

Phase 2 attribution: serialization plus write 810.946 ms; temp-file persist 35.589 us; SHA-256 finalization 932 ns. Standalone hashing took 0.45 s wall. Atomic persistence and pretty JSON remain unchanged.

Phase 4a-4d are in one coherent commit because the shared index changes the topology and association signatures together. The queue preserved the baseline hash, so no pass-order fallback was needed.

## Verification

- `cargo build -p cadmpeg --release`
- `cargo test-fast`
- `cargo test -p cadmpeg --all-targets`
- `cargo test -p cadmpeg-core --all-targets`
- Release decode hash and byte comparison against the baseline
- `cadmpeg validate` exit 0
- Parser, STEP, CLI, and seekable/unseekable root-read tests

Deferred follow-ups remain the span-based lexer, the exchange `BTreeMap` replacement, compact output, and IR string-ID representation.