### PR TITLE
Optimize STEP decoder hot paths

### DIFF
--- a/crates/cadmpeg-codec-step/src/lex.rs
+++ b/crates/cadmpeg-codec-step/src/lex.rs
@@ -70,29 +70,44 @@ pub struct LexError {
 
 /// Tokenize one complete clear-text exchange structure.
 pub fn lex(input: &[u8]) -> Result<Vec<Token>, LexError> {
-    let mut lexer = Lexer { input, at: 0 };
+    let mut lexer = Lexer::new(input);
     let mut tokens = Vec::new();
-    while lexer.skip_trivia()? {
-        tokens.push(lexer.token()?);
-        if matches!(
-            tokens.last().map(|token| &token.kind),
-            Some(TokenKind::Semicolon)
-        ) && matches!(
-            tokens.get(tokens.len().saturating_sub(2)).map(|token| &token.kind),
-            Some(TokenKind::Name(name)) if name == "SIGNATURE"
-        ) {
-            lexer.skip_signature_payload()?;
-        }
+    while let Some(token) = lexer.next_token()? {
+        tokens.push(token);
     }
     Ok(tokens)
 }
 
-struct Lexer<'a> {
+pub(crate) struct Lexer<'a> {
     input: &'a [u8],
     at: usize,
+    previous_was_signature: bool,
 }
 
-impl Lexer<'_> {
+impl<'a> Lexer<'a> {
+    pub(crate) fn new(input: &'a [u8]) -> Self {
+        Self {
+            input,
+            at: 0,
+            previous_was_signature: false,
+        }
+    }
+
+    pub(crate) fn next_token(&mut self) -> Result<Option<Token>, LexError> {
+        if !self.skip_trivia()? {
+            return Ok(None);
+        }
+        let token = self.token()?;
+        let skip_signature =
+            self.previous_was_signature && matches!(&token.kind, TokenKind::Semicolon);
+        self.previous_was_signature =
+            matches!(&token.kind, TokenKind::Name(name) if name == "SIGNATURE");
+        if skip_signature {
+            self.skip_signature_payload()?;
+        }
+        Ok(Some(token))
+    }
+
     fn skip_signature_payload(&mut self) -> Result<(), LexError> {
         let start = self.at;
         let tail = &self.input[start..];

--- a/crates/cadmpeg-codec-step/src/parse.rs
+++ b/crates/cadmpeg-codec-step/src/parse.rs
@@ -8,9 +8,9 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::ops::Range;
-use std::sync::OnceLock;
+use std::sync::{Arc, Mutex, OnceLock};
 
-use crate::lex::{lex, BinaryValue, LexError, Token, TokenKind};
+use crate::lex::{BinaryValue, LexError, Lexer, Token, TokenKind};
 
 /// One parsed Part 21 parameter value.
 #[derive(Debug, Clone, PartialEq)]
@@ -113,14 +113,19 @@ pub struct Exchange {
     entity_ids: EntityIndex,
 }
 
+type EntityUnionCache = Mutex<HashMap<Vec<String>, Arc<[u64]>>>;
+
 #[derive(Debug, Default)]
-struct EntityIndex(OnceLock<HashMap<String, Vec<u64>>>);
+struct EntityIndex(
+    OnceLock<HashMap<String, Vec<u64>>>,
+    OnceLock<EntityUnionCache>,
+);
 
 const EMPTY_ENTITY_IDS: &[u64] = &[];
 
 enum EntityIdIter<'a> {
     Borrowed(std::slice::Iter<'a, u64>),
-    Owned(std::vec::IntoIter<u64>),
+    Shared { ids: Arc<[u64]>, at: usize },
 }
 
 impl Iterator for EntityIdIter<'_> {
@@ -129,7 +134,11 @@ impl Iterator for EntityIdIter<'_> {
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             Self::Borrowed(ids) => ids.next().copied(),
-            Self::Owned(ids) => ids.next(),
+            Self::Shared { ids, at } => {
+                let id = ids.get(*at).copied();
+                *at += usize::from(id.is_some());
+                id
+            }
         }
     }
 }
@@ -163,6 +172,30 @@ impl Exchange {
         })
     }
 
+    fn entity_unions(&self) -> &EntityUnionCache {
+        self.entity_ids.1.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    pub(crate) fn has_entity(&self, name: &str) -> bool {
+        self.entity_ids().contains_key(name)
+    }
+
+    pub(crate) fn has_entity_matching(&self, matches: impl Fn(&str) -> bool) -> bool {
+        self.entity_ids().keys().any(|name| matches(name))
+    }
+
+    pub(crate) fn matching_entity_ids(&self, matches: impl Fn(&str) -> bool) -> Vec<u64> {
+        let mut ids = self
+            .entity_ids()
+            .iter()
+            .filter(|(name, _)| matches(name))
+            .flat_map(|(_, ids)| ids.iter().copied())
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+        ids.dedup();
+        ids
+    }
+
     pub(crate) fn entities(&self, name: &str) -> impl Iterator<Item = (u64, &RawRecord)> {
         self.entity_ids()
             .get(name)
@@ -182,22 +215,37 @@ impl Exchange {
                 .map_or(EMPTY_ENTITY_IDS, Vec::as_slice);
             EntityIdIter::Borrowed(ids.iter())
         } else {
-            let capacity = names
+            let mut key = names
                 .iter()
-                .filter_map(|name| self.entity_ids().get(*name))
-                .map(Vec::len)
-                .sum();
-            let mut ids = Vec::with_capacity(capacity);
-            ids.extend(
-                names
-                    .iter()
-                    .filter_map(|name| self.entity_ids().get(*name))
-                    .flatten()
-                    .copied(),
-            );
-            ids.sort_unstable();
-            ids.dedup();
-            EntityIdIter::Owned(ids.into_iter())
+                .map(|name| (*name).to_owned())
+                .collect::<Vec<_>>();
+            key.sort_unstable();
+            key.dedup();
+            let mut unions = self
+                .entity_unions()
+                .lock()
+                .expect("entity index lock poisoned");
+            let ids = unions
+                .entry(key.clone())
+                .or_insert_with(|| {
+                    let capacity = key
+                        .iter()
+                        .filter_map(|name| self.entity_ids().get(name))
+                        .map(Vec::len)
+                        .sum();
+                    let mut ids = Vec::with_capacity(capacity);
+                    ids.extend(
+                        key.iter()
+                            .filter_map(|name| self.entity_ids().get(name))
+                            .flatten()
+                            .copied(),
+                    );
+                    ids.sort_unstable();
+                    ids.dedup();
+                    Arc::from(ids.into_boxed_slice())
+                })
+                .clone();
+            EntityIdIter::Shared { ids, at: 0 }
         };
         ids.filter_map(|id| self.records.get(&id).map(|record| (id, record)))
     }
@@ -240,23 +288,26 @@ pub struct ParseDiagnostic {
 
 /// Parse one complete clear-text exchange structure and resolve DATA references.
 pub fn parse(input: &[u8]) -> Result<(Exchange, Vec<ParseDiagnostic>), ParseError> {
+    let mut lexer = Lexer::new(input);
     Parser {
-        tokens: lex(input)?,
-        at: 0,
+        current: lexer.next_token()?,
+        lexer,
+        last_end: 0,
         depth: 0,
         diagnostics: Vec::new(),
     }
     .exchange()
 }
 
-struct Parser {
-    tokens: Vec<Token>,
-    at: usize,
+struct Parser<'a> {
+    lexer: Lexer<'a>,
+    current: Option<Token>,
+    last_end: usize,
     depth: usize,
     diagnostics: Vec<ParseDiagnostic>,
 }
 
-impl Parser {
+impl Parser<'_> {
     fn exchange(mut self) -> Result<(Exchange, Vec<ParseDiagnostic>), ParseError> {
         self.name("ISO-10303-21")?;
         self.punct(&TokenKind::Semicolon)?;
@@ -273,7 +324,7 @@ impl Parser {
         self.punct(&TokenKind::Semicolon)?;
         let mut anchors = Vec::new();
         if self.peek_name("ANCHOR") {
-            self.at += 1;
+            self.next_kind()?;
             self.punct(&TokenKind::Semicolon)?;
             while !self.peek_name("ENDSEC") {
                 let TokenKind::Resource(name) = self.next_kind()? else {
@@ -284,12 +335,12 @@ impl Parser {
                 self.punct(&TokenKind::Semicolon)?;
                 anchors.push(AnchorEntry { name, value });
             }
-            self.at += 1;
+            self.next_kind()?;
             self.punct(&TokenKind::Semicolon)?;
         }
         let mut reference_entries = Vec::new();
         if self.peek_name("REFERENCE") {
-            self.at += 1;
+            self.next_kind()?;
             self.punct(&TokenKind::Semicolon)?;
             while !self.peek_name("ENDSEC") {
                 let TokenKind::Resource(name) = self.next_kind()? else {
@@ -302,13 +353,13 @@ impl Parser {
                 self.punct(&TokenKind::Semicolon)?;
                 reference_entries.push(ReferenceEntry { name, uri });
             }
-            self.at += 1;
+            self.next_kind()?;
             self.punct(&TokenKind::Semicolon)?;
         }
         let mut data = Vec::new();
         let mut records = BTreeMap::new();
         while self.peek_name("DATA") {
-            self.at += 1;
+            self.next_kind()?;
             let parameters = if self.peek(&TokenKind::LParen) {
                 self.parameters()?
             } else {
@@ -333,15 +384,15 @@ impl Parser {
         }
         let signature = if self.peek_name("SIGNATURE") {
             let start = self.current_offset();
-            self.at += 1;
+            self.next_kind()?;
             self.punct(&TokenKind::Semicolon)?;
             while !self.peek_name("ENDSEC") {
-                self.at += 1;
-                if self.at >= self.tokens.len() {
+                if self.current.is_none() {
                     return self.err("unterminated SIGNATURE section");
                 }
+                self.next_kind()?;
             }
-            self.at += 1;
+            self.next_kind()?;
             self.punct(&TokenKind::Semicolon)?;
             Some(start..self.previous_end())
         } else {
@@ -349,7 +400,7 @@ impl Parser {
         };
         self.name("END-ISO-10303-21")?;
         self.punct(&TokenKind::Semicolon)?;
-        if self.at != self.tokens.len() {
+        if self.current.is_some() {
             return self.err("tokens after exchange terminator");
         }
         if !anchors.is_empty() {
@@ -420,12 +471,12 @@ impl Parser {
         };
         self.punct(&TokenKind::Equals)?;
         let partials = if self.peek(&TokenKind::LParen) {
-            self.at += 1;
+            self.next_kind()?;
             let mut parts = Vec::new();
             while !self.peek(&TokenKind::RParen) {
                 parts.push(self.partial()?);
             }
-            self.at += 1;
+            self.next_kind()?;
             let mut canonical_names = parts
                 .iter()
                 .map(|part| part.name.clone())
@@ -488,13 +539,13 @@ impl Parser {
         self.punct(&TokenKind::LParen)?;
         let mut values = Vec::new();
         if self.peek(&TokenKind::RParen) {
-            self.at += 1;
+            self.next_kind()?;
             return Ok(values);
         }
         loop {
             values.push(self.value()?);
             if self.peek(&TokenKind::Comma) {
-                self.at += 1;
+                self.next_kind()?;
             } else {
                 break;
             }
@@ -559,30 +610,28 @@ impl Parser {
         }
     }
     fn peek(&self, expected: &TokenKind) -> bool {
-        self.tokens
-            .get(self.at)
-            .is_some_and(|t| std::mem::discriminant(&t.kind) == std::mem::discriminant(expected))
+        self.current.as_ref().is_some_and(|token| {
+            std::mem::discriminant(&token.kind) == std::mem::discriminant(expected)
+        })
     }
     fn peek_name(&self, expected: &str) -> bool {
-        matches!(self.tokens.get(self.at).map(|t| &t.kind), Some(TokenKind::Name(name)) if name == expected)
+        matches!(self.current.as_ref().map(|token| &token.kind), Some(TokenKind::Name(name)) if name == expected)
     }
     fn next_kind(&mut self) -> Result<TokenKind, ParseError> {
-        let Some(token) = self.tokens.get_mut(self.at) else {
+        let Some(token) = self.current.take() else {
             return self.err("unexpected end of input");
         };
-        self.at += 1;
-        Ok(std::mem::replace(&mut token.kind, TokenKind::Omitted))
+        self.last_end = token.span.end;
+        self.current = self.lexer.next_token()?;
+        Ok(token.kind)
     }
     fn current_offset(&self) -> usize {
-        self.tokens
-            .get(self.at)
-            .map_or_else(|| self.previous_end(), |t| t.span.start)
+        self.current
+            .as_ref()
+            .map_or(self.last_end, |token| token.span.start)
     }
     fn previous_end(&self) -> usize {
-        self.at
-            .checked_sub(1)
-            .and_then(|i| self.tokens.get(i))
-            .map_or(0, |t| t.span.end)
+        self.last_end
     }
     fn err<T>(&self, message: &str) -> Result<T, ParseError> {
         Self::err_at(self.current_offset(), message)
@@ -712,6 +761,24 @@ mod tests {
         let (untouched, _) = parse(source).expect("required invariant");
         assert_eq!(indexed.entities("POINT").count(), 1);
         assert_eq!(indexed, untouched);
+    }
+
+    #[test]
+    fn entity_unions_are_ordered_unique_and_name_order_independent() {
+        let source = b"ISO-10303-21;HEADER;ENDSEC;DATA;#2=(A()B());#1=B();ENDSEC;END-ISO-10303-21;";
+        let (exchange, _) = parse(source).expect("required invariant");
+
+        let forward = exchange
+            .entities_any(&["A", "B"])
+            .map(|(id, _)| id)
+            .collect::<Vec<_>>();
+        let reverse = exchange
+            .entities_any(&["B", "A"])
+            .map(|(id, _)| id)
+            .collect::<Vec<_>>();
+
+        assert_eq!(forward, vec![1, 2]);
+        assert_eq!(reverse, forward);
     }
 
     #[test]

--- a/crates/cadmpeg-codec-step/src/reader/mod.rs
+++ b/crates/cadmpeg-codec-step/src/reader/mod.rs
@@ -112,7 +112,6 @@ fn decode_exchange_mode(
     let dependencies = dependencies::decode(exchange);
     let carrier_index = index::CarrierIndex::from_ir(&ir);
     let topology = topology::decode(exchange, &mut ir, &carrier_index);
-    let carrier_index = index::CarrierIndex::from_ir(&ir);
     let owned_carriers = geometry::topology_owned_carriers(&ir, &carrier_index);
     geometry::associate_topology_carriers(exchange, &mut ir, &carrier_index, &owned_carriers);
     geometry::associate_free_geometric_set_members(

--- a/crates/cadmpeg-codec-step/src/reader/pmi.rs
+++ b/crates/cadmpeg-codec-step/src/reader/pmi.rs
@@ -21,11 +21,16 @@ pub(super) struct PmiResult {
 }
 
 pub(super) fn decode(exchange: &Exchange, geometry: &GeometryResult, ir: &mut CadIr) -> PmiResult {
+    if !exchange.has_entity_matching(is_pmi_entity_name) {
+        return PmiResult {
+            typed_records: BTreeSet::new(),
+            warnings: Vec::new(),
+        };
+    }
     let aspects = exchange
-        .records
-        .iter()
+        .entities_any(&["SHAPE_ASPECT", "DATUM_FEATURE", "DATUM"])
         .filter(|(_, record)| is_shape_aspect(record))
-        .map(|(&id, _)| id)
+        .map(|(id, _)| id)
         .collect::<BTreeSet<_>>();
     let mut typed = BTreeSet::new();
     let mut warnings = Vec::new();
@@ -34,10 +39,7 @@ pub(super) fn decode(exchange: &Exchange, geometry: &GeometryResult, ir: &mut Ca
     let mut presentation_semantics = BTreeMap::<u64, Vec<u64>>::new();
     let characteristic_values =
         characteristic_values(exchange, geometry.length_scale, geometry.plane_angle_scale);
-    for (&id, record) in &exchange.records {
-        if record.simple_name() != Some("DATUM") {
-            continue;
-        }
+    for (id, record) in exchange.entities("DATUM") {
         let identification = record
             .parameters()
             .iter()
@@ -55,10 +57,7 @@ pub(super) fn decode(exchange: &Exchange, geometry: &GeometryResult, ir: &mut Ca
         typed.insert(id);
     }
 
-    for (&id, record) in &exchange.records {
-        if record.simple_name() != Some("DATUM_SYSTEM") {
-            continue;
-        }
+    for (id, record) in exchange.entities("DATUM_SYSTEM") {
         let constituents = record
             .parameters()
             .iter()
@@ -103,7 +102,10 @@ pub(super) fn decode(exchange: &Exchange, geometry: &GeometryResult, ir: &mut Ca
         typed.extend(datum_records);
     }
 
-    for (&id, record) in &exchange.records {
+    for id in exchange.matching_entity_ids(|name| dimension_kind(Some(name)).is_some()) {
+        let Some(record) = exchange.records.get(&id) else {
+            continue;
+        };
         let Some(mut kind) = dimension_kind(record.simple_name()) else {
             continue;
         };
@@ -149,10 +151,7 @@ pub(super) fn decode(exchange: &Exchange, geometry: &GeometryResult, ir: &mut Ca
         typed.insert(id);
     }
 
-    for (&id, record) in &exchange.records {
-        if record.simple_name() != Some("PLUS_MINUS_TOLERANCE") {
-            continue;
-        }
+    for (id, record) in exchange.entities("PLUS_MINUS_TOLERANCE") {
         let refs = record
             .parameters()
             .iter()
@@ -236,7 +235,10 @@ pub(super) fn decode(exchange: &Exchange, geometry: &GeometryResult, ir: &mut Ca
         }
     }
 
-    for (&id, record) in &exchange.records {
+    for id in exchange.matching_entity_ids(|name| tolerance_kind(Some(name)).is_some()) {
+        let Some(record) = exchange.records.get(&id) else {
+            continue;
+        };
         let Some(tolerance) = record
             .partials
             .iter()
@@ -303,10 +305,7 @@ pub(super) fn decode(exchange: &Exchange, geometry: &GeometryResult, ir: &mut Ca
         }));
     }
 
-    for (&id, record) in &exchange.records {
-        if record.simple_name() != Some("DRAUGHTING_MODEL_ITEM_ASSOCIATION") {
-            continue;
-        }
+    for (id, record) in exchange.entities("DRAUGHTING_MODEL_ITEM_ASSOCIATION") {
         let Some(definition) = record.parameter(2).and_then(ValueExt::reference) else {
             continue;
         };
@@ -321,7 +320,10 @@ pub(super) fn decode(exchange: &Exchange, geometry: &GeometryResult, ir: &mut Ca
         }
     }
 
-    for (&id, record) in &exchange.records {
+    for id in exchange.matching_entity_ids(is_presentation_annotation) {
+        let Some(record) = exchange.records.get(&id) else {
+            continue;
+        };
         let Some(name) = record.simple_name() else {
             continue;
         };
@@ -369,13 +371,10 @@ pub(super) fn decode(exchange: &Exchange, geometry: &GeometryResult, ir: &mut Ca
         typed.extend(text_records);
         typed.extend(placement_records);
     }
-    for (&id, record) in &exchange.records {
-        if matches!(
-            record.simple_name(),
-            Some("DRAUGHTING_MODEL" | "ANNOTATION_PLANE" | "DRAUGHTING_CALLOUT")
-        ) {
-            typed.insert(id);
-        }
+    for (id, _) in
+        exchange.entities_any(&["DRAUGHTING_MODEL", "ANNOTATION_PLANE", "DRAUGHTING_CALLOUT"])
+    {
+        typed.insert(id);
     }
 
     let targeted_aspects = ir
@@ -401,10 +400,7 @@ fn mark_characteristic_representations(
     annotations: &BTreeMap<u64, usize>,
     typed: &mut BTreeSet<u64>,
 ) {
-    for (&id, record) in &exchange.records {
-        if record.simple_name() != Some("DIMENSIONAL_CHARACTERISTIC_REPRESENTATION") {
-            continue;
-        }
+    for (id, record) in exchange.entities("DIMENSIONAL_CHARACTERISTIC_REPRESENTATION") {
         let record_references = record
             .parameters()
             .iter()
@@ -683,6 +679,24 @@ fn pmi_id(id: u64) -> PmiId {
     PmiId(format!("step:presentation:pmi#{id}"))
 }
 
+fn is_pmi_entity_name(name: &str) -> bool {
+    matches!(
+        name,
+        "SHAPE_ASPECT"
+            | "DATUM_FEATURE"
+            | "DATUM"
+            | "DATUM_SYSTEM"
+            | "PLUS_MINUS_TOLERANCE"
+            | "DRAUGHTING_MODEL_ITEM_ASSOCIATION"
+            | "DIMENSIONAL_CHARACTERISTIC_REPRESENTATION"
+            | "DRAUGHTING_MODEL"
+            | "ANNOTATION_PLANE"
+            | "DRAUGHTING_CALLOUT"
+    ) || dimension_kind(Some(name)).is_some()
+        || tolerance_kind(Some(name)).is_some()
+        || is_presentation_annotation(name)
+}
+
 fn is_shape_aspect(record: &RawRecord) -> bool {
     matches!(
         record.simple_name(),
@@ -745,11 +759,7 @@ fn characteristic_values(
     angle_scale: f64,
 ) -> BTreeMap<u64, Vec<PmiValue>> {
     let mut result = BTreeMap::<u64, Vec<PmiValue>>::new();
-    for record in exchange
-        .records
-        .values()
-        .filter(|record| record.simple_name() == Some("DIMENSIONAL_CHARACTERISTIC_REPRESENTATION"))
-    {
+    for (_, record) in exchange.entities("DIMENSIONAL_CHARACTERISTIC_REPRESENTATION") {
         let Some(characteristic) = record.parameters().iter().flat_map(references).find(|id| {
             exchange
                 .records

--- a/crates/cadmpeg-codec-step/src/reader/topology.rs
+++ b/crates/cadmpeg-codec-step/src/reader/topology.rs
@@ -73,11 +73,9 @@ pub(super) fn decode(
     let vertices = vertex_defs(exchange);
     let edges = edge_defs(exchange);
     let oriented = oriented_defs(exchange);
+    let shells = shell_defs(exchange);
     let point_positions = carrier_index;
-    for (&vertex_id, vertex) in &exchange.records {
-        if !has_type(vertex, "VERTEX_POINT") {
-            continue;
-        }
+    for (vertex_id, vertex) in exchange.entities("VERTEX_POINT") {
         let Some(point_id) = named_reference(vertex, "VERTEX_POINT", 1, 0) else {
             result.warnings.push(format!(
                 "VERTEX_POINT #{vertex_id} has no resolvable point carrier"
@@ -156,10 +154,7 @@ pub(super) fn decode(
             ));
         }
     }
-    for (&model, record) in &exchange.records {
-        if !has_type(record, "SHELL_BASED_WIREFRAME_MODEL") {
-            continue;
-        }
+    for (model, record) in exchange.entities("SHELL_BASED_WIREFRAME_MODEL") {
         let scope_root = named_refs(record, "SHELL_BASED_WIREFRAME_MODEL", 1)
             .into_iter()
             .flatten()
@@ -215,20 +210,14 @@ pub(super) fn decode(
         .map(|pcurve| pcurve.id.clone())
         .collect::<BTreeSet<_>>();
     let mut built_roots = BTreeMap::<RootKey, RootBuilt>::new();
-    for (&id, record) in &exchange.records {
-        if ![
-            "SHELL_BASED_SURFACE_MODEL",
-            "FACE_BASED_SURFACE_MODEL",
-            "FACETED_BREP",
-            "MANIFOLD_SOLID_BREP",
-            "BREP_WITH_VOIDS",
-        ]
-        .iter()
-        .any(|name| has_type(record, name))
-        {
-            continue;
-        }
-        let Some(key) = root_key(record, exchange) else {
+    for (id, record) in exchange.entities_any(&[
+        "SHELL_BASED_SURFACE_MODEL",
+        "FACE_BASED_SURFACE_MODEL",
+        "FACETED_BREP",
+        "MANIFOLD_SOLID_BREP",
+        "BREP_WITH_VOIDS",
+    ]) {
+        let Some(key) = root_key(record, exchange, &shells) else {
             result.warnings.push(format!(
                 "STEP topology root #{id} does not resolve to a complete connected topology graph",
             ));
@@ -257,6 +246,7 @@ pub(super) fn decode(
             &vertices,
             &edges,
             &oriented,
+            &shells,
             &decoded_pcurves,
             point_positions,
             scope_root,
@@ -318,10 +308,7 @@ pub(super) fn decode(
             }
         }
     }
-    for (&id, record) in &exchange.records {
-        if record.simple_name() != Some("GEOMETRICALLY_BOUNDED_SURFACE_SHAPE_REPRESENTATION") {
-            continue;
-        }
+    for (id, record) in exchange.entities("GEOMETRICALLY_BOUNDED_SURFACE_SHAPE_REPRESENTATION") {
         let omitted = geometric_set_omissions(record, exchange, carrier_index);
         if !omitted.is_empty() {
             result.warnings.push(format!(
@@ -360,7 +347,11 @@ pub(super) fn decode(
             result.typed_records.append(&mut built.typed);
         }
     }
-    for (&id, record) in &exchange.records {
+    for (id, record) in exchange.entities_any(&[
+        "SHAPE_REPRESENTATION",
+        "ADVANCED_BREP_SHAPE_REPRESENTATION",
+        "GEOMETRICALLY_BOUNDED_WIREFRAME_SHAPE_REPRESENTATION",
+    ]) {
         if !matches!(
             record.simple_name(),
             Some(
@@ -391,7 +382,11 @@ pub(super) fn decode(
             &mut result.typed_records,
         );
     }
-    for (&id, record) in &exchange.records {
+    for (id, record) in exchange.entities_any(&[
+        "MANIFOLD_SURFACE_SHAPE_REPRESENTATION",
+        "ADVANCED_BREP_SHAPE_REPRESENTATION",
+        "SHAPE_REPRESENTATION",
+    ]) {
         if !matches!(
             record.simple_name(),
             Some(
@@ -1012,9 +1007,8 @@ struct OrientedDef {
 
 fn vertex_defs(exchange: &Exchange) -> BTreeMap<u64, VertexDef> {
     exchange
-        .records
-        .iter()
-        .filter_map(|(&id, r)| {
+        .entities("VERTEX_POINT")
+        .filter_map(|(id, r)| {
             if !has_type(r, "VERTEX_POINT") {
                 return None;
             }
@@ -1028,22 +1022,37 @@ fn vertex_defs(exchange: &Exchange) -> BTreeMap<u64, VertexDef> {
         .collect()
 }
 fn edge_defs(exchange: &Exchange) -> BTreeMap<u64, EdgeDef> {
-    exchange
-        .records
-        .iter()
-        .filter_map(|(&id, _)| {
-            edge_def_for(id, exchange, &mut BTreeSet::new()).map(|edge| (id, edge))
-        })
-        .collect()
+    let mut edges = BTreeMap::new();
+    let mut cache = BTreeMap::new();
+    let mut active = BTreeSet::new();
+    for (id, _) in exchange.entities_any(&[
+        "EDGE_CURVE",
+        "SEAM_EDGE",
+        "ORIENTED_EDGE",
+        "SUBEDGE",
+        "EDGE",
+    ]) {
+        if let Some(edge) = edge_def_for(id, exchange, &mut active, &mut cache) {
+            edges.insert(id, edge);
+        }
+    }
+    edges
 }
 
-fn edge_def_for(id: u64, exchange: &Exchange, active: &mut BTreeSet<u64>) -> Option<EdgeDef> {
+fn edge_def_for(
+    id: u64,
+    exchange: &Exchange,
+    active: &mut BTreeSet<u64>,
+    cache: &mut BTreeMap<u64, Option<EdgeDef>>,
+) -> Option<EdgeDef> {
+    if let Some(edge) = cache.get(&id) {
+        return edge.clone();
+    }
     if !active.insert(id) {
         return None;
     }
-    let record = exchange.records.get(&id)?;
-    let result = match most_specific(
-        record,
+    let result = (|| match most_specific(
+        exchange.records.get(&id)?,
         &[
             "EDGE_CURVE",
             "SEAM_EDGE",
@@ -1053,6 +1062,7 @@ fn edge_def_for(id: u64, exchange: &Exchange, active: &mut BTreeSet<u64>) -> Opt
         ],
     )? {
         "EDGE_CURVE" => {
+            let record = exchange.records.get(&id)?;
             let (start, end) = edge_vertices(record)?;
             Some(EdgeDef {
                 start,
@@ -1064,6 +1074,7 @@ fn edge_def_for(id: u64, exchange: &Exchange, active: &mut BTreeSet<u64>) -> Opt
             })
         }
         "EDGE" => {
+            let record = exchange.records.get(&id)?;
             let (start, end) = edge_vertices(record)?;
             Some(EdgeDef {
                 start,
@@ -1075,9 +1086,10 @@ fn edge_def_for(id: u64, exchange: &Exchange, active: &mut BTreeSet<u64>) -> Opt
             })
         }
         "SUBEDGE" => {
+            let record = exchange.records.get(&id)?;
             let (start, end) = edge_vertices(record)?;
             let parent = subedge_parent(record)?;
-            let parent_def = edge_def_for(parent, exchange, active)?;
+            let parent_def = edge_def_for(parent, exchange, active, cache)?;
             Some(EdgeDef {
                 start,
                 end,
@@ -1088,8 +1100,9 @@ fn edge_def_for(id: u64, exchange: &Exchange, active: &mut BTreeSet<u64>) -> Opt
             })
         }
         "ORIENTED_EDGE" | "SEAM_EDGE" => {
+            let record = exchange.records.get(&id)?;
             let element = oriented_edge_reference(record)?;
-            let element_def = edge_def_for(element, exchange, active)?;
+            let element_def = edge_def_for(element, exchange, active, cache)?;
             let forward = oriented_edge_forward(record)?;
             Some(EdgeDef {
                 start: element_def.start,
@@ -1114,8 +1127,9 @@ fn edge_def_for(id: u64, exchange: &Exchange, active: &mut BTreeSet<u64>) -> Opt
             })
         }
         _ => None,
-    };
+    })();
     active.remove(&id);
+    cache.insert(id, result.clone());
     result
 }
 
@@ -1144,9 +1158,8 @@ fn edge_curve_id_reported(
 }
 fn oriented_defs(exchange: &Exchange) -> BTreeMap<u64, OrientedDef> {
     exchange
-        .records
-        .iter()
-        .filter_map(|(&id, r)| {
+        .entities_any(&["ORIENTED_EDGE", "SEAM_EDGE"])
+        .filter_map(|(id, r)| {
             if !has_type(r, "ORIENTED_EDGE") && !has_type(r, "SEAM_EDGE") {
                 return None;
             }
@@ -1494,15 +1507,20 @@ fn root_shell_steps(root: &RawRecord, exchange: &Exchange) -> Option<Vec<u64>> {
     None
 }
 
-fn root_key(root: &RawRecord, exchange: &Exchange) -> Option<RootKey> {
+fn root_key(
+    root: &RawRecord,
+    exchange: &Exchange,
+    shell_definitions: &BTreeMap<u64, ShellDef>,
+) -> Option<RootKey> {
     let mut shell_keys = Vec::new();
     let mut resolved = 0;
     for shell in root_shell_steps(root, exchange)? {
         let key = if has_type(root, "FACE_BASED_SURFACE_MODEL") {
             Some((shell, Some(true)))
         } else {
-            resolve_shell(shell, exchange, &mut BTreeSet::new())
-                .map(|(resolved_shell, forward)| (resolved_shell, Some(forward)))
+            shell_definitions
+                .get(&shell)
+                .map(|definition| (definition.base, Some(definition.forward)))
                 .or(Some((shell, None)))
         };
         if key.as_ref().is_some_and(|(_, forward)| forward.is_some()) {
@@ -1528,6 +1546,7 @@ fn build(
     vdefs: &BTreeMap<u64, VertexDef>,
     edefs: &BTreeMap<u64, EdgeDef>,
     odefs: &BTreeMap<u64, OrientedDef>,
+    shell_definitions: &BTreeMap<u64, ShellDef>,
     decoded_pcurves: &BTreeSet<PcurveId>,
     point_positions: &CarrierIndex,
     scope_root: bool,
@@ -1557,6 +1576,7 @@ fn build(
             vdefs,
             edefs,
             odefs,
+            shell_definitions,
             decoded_pcurves,
             point_positions,
             &shell_steps,
@@ -1584,9 +1604,8 @@ fn build(
         let shell_step = if has_type(root, "FACE_BASED_SURFACE_MODEL") {
             shell_reference
         } else {
-            let mut typed = BTreeSet::new();
-            match resolve_shell(shell_reference, exchange, &mut typed) {
-                Some((shell_step, _)) => shell_step,
+            match shell_definitions.get(&shell_reference) {
+                Some(definition) => definition.base,
                 None => {
                     failure.get_or_insert(BuildFailure {
                         record_id: shell_reference,
@@ -1617,6 +1636,7 @@ fn build(
             vdefs,
             edefs,
             odefs,
+            shell_definitions,
             decoded_pcurves,
             point_positions,
             &[shell_reference],
@@ -1651,6 +1671,7 @@ fn build_one(
     vdefs: &BTreeMap<u64, VertexDef>,
     edefs: &BTreeMap<u64, EdgeDef>,
     odefs: &BTreeMap<u64, OrientedDef>,
+    shell_definitions: &BTreeMap<u64, ShellDef>,
     decoded_pcurves: &BTreeSet<PcurveId>,
     point_positions: &CarrierIndex,
     shell_steps: &[u64],
@@ -1706,7 +1727,7 @@ fn build_one(
             (shell_reference, true)
         } else {
             require_carrier(
-                resolve_shell(shell_reference, exchange, &mut typed),
+                shell_def_for(shell_reference, shell_definitions, &mut typed),
                 failure,
                 shell_reference,
                 "shell carrier",
@@ -2280,7 +2301,9 @@ fn build_one(
             shell_reference
         } else {
             require_carrier(
-                resolve_shell(shell_reference, exchange, &mut BTreeSet::new()),
+                shell_definitions
+                    .get(&shell_reference)
+                    .map(|definition| (definition.base, definition.forward)),
                 failure,
                 shell_reference,
                 "shell carrier",
@@ -2522,33 +2545,84 @@ fn associated_pcurves(
         .collect()
 }
 
-fn resolve_shell(
+#[derive(Clone)]
+struct ShellDef {
+    base: u64,
+    forward: bool,
+    typed: BTreeSet<u64>,
+}
+
+fn shell_defs(exchange: &Exchange) -> BTreeMap<u64, ShellDef> {
+    let mut cache = BTreeMap::<u64, Option<ShellDef>>::new();
+    let mut active = BTreeSet::new();
+    for (id, _) in exchange.entities_any(&[
+        "ORIENTED_OPEN_SHELL",
+        "ORIENTED_CLOSED_SHELL",
+        "OPEN_SHELL",
+        "CLOSED_SHELL",
+    ]) {
+        shell_def_cached(id, exchange, &mut active, &mut cache);
+    }
+    cache
+        .into_iter()
+        .filter_map(|(id, definition)| definition.map(|definition| (id, definition)))
+        .collect()
+}
+
+fn shell_def_cached(
     reference: u64,
     exchange: &Exchange,
+    active: &mut BTreeSet<u64>,
+    cache: &mut BTreeMap<u64, Option<ShellDef>>,
+) -> Option<ShellDef> {
+    if let Some(definition) = cache.get(&reference) {
+        return definition.clone();
+    }
+    if !active.insert(reference) {
+        return None;
+    }
+    let result = (|| {
+        let record = exchange.records.get(&reference)?;
+        match most_specific(
+            record,
+            &[
+                "ORIENTED_OPEN_SHELL",
+                "ORIENTED_CLOSED_SHELL",
+                "OPEN_SHELL",
+                "CLOSED_SHELL",
+            ],
+        )? {
+            "OPEN_SHELL" | "CLOSED_SHELL" => Some(ShellDef {
+                base: reference,
+                forward: true,
+                typed: BTreeSet::new(),
+            }),
+            "ORIENTED_OPEN_SHELL" | "ORIENTED_CLOSED_SHELL" => {
+                let shell_type =
+                    most_specific(record, &["ORIENTED_OPEN_SHELL", "ORIENTED_CLOSED_SHELL"])?;
+                let element = named_reference(record, shell_type, 1, 0)?;
+                let orientation = named_logical(record, shell_type, 2, 0)?;
+                let mut definition = shell_def_cached(element, exchange, active, cache)?;
+                definition.forward = definition.forward == orientation;
+                definition.typed.insert(reference);
+                Some(definition)
+            }
+            _ => None,
+        }
+    })();
+    active.remove(&reference);
+    cache.insert(reference, result.clone());
+    result
+}
+
+fn shell_def_for(
+    reference: u64,
+    shells: &BTreeMap<u64, ShellDef>,
     typed: &mut BTreeSet<u64>,
 ) -> Option<(u64, bool)> {
-    let record = exchange.records.get(&reference)?;
-    match most_specific(
-        record,
-        &[
-            "ORIENTED_OPEN_SHELL",
-            "ORIENTED_CLOSED_SHELL",
-            "OPEN_SHELL",
-            "CLOSED_SHELL",
-        ],
-    )? {
-        "OPEN_SHELL" | "CLOSED_SHELL" => Some((reference, true)),
-        "ORIENTED_OPEN_SHELL" | "ORIENTED_CLOSED_SHELL" => {
-            typed.insert(reference);
-            let shell_type =
-                most_specific(record, &["ORIENTED_OPEN_SHELL", "ORIENTED_CLOSED_SHELL"])?;
-            let element = named_reference(record, shell_type, 1, 0)?;
-            let orientation = named_logical(record, shell_type, 2, 0)?;
-            let (base, element_orientation) = resolve_shell(element, exchange, typed)?;
-            Some((base, element_orientation == orientation))
-        }
-        _ => None,
-    }
+    let definition = shells.get(&reference)?;
+    typed.extend(definition.typed.iter().copied());
+    Some((definition.base, definition.forward))
 }
 
 #[derive(Default)]

--- a/crates/cadmpeg-codec-step/src/reader/validation.rs
+++ b/crates/cadmpeg-codec-step/src/reader/validation.rs
@@ -28,10 +28,18 @@ pub(super) fn decode(
     geometry: &GeometryResult,
     ir: &mut CadIr,
 ) -> ValidationResult {
+    if !exchange.has_entity("PROPERTY_DEFINITION")
+        || !exchange.has_entity("PROPERTY_DEFINITION_REPRESENTATION")
+    {
+        return ValidationResult {
+            typed_records: BTreeSet::new(),
+            notes: Vec::new(),
+            warnings: Vec::new(),
+        };
+    }
     let representations = exchange
-        .records
-        .iter()
-        .filter_map(|(&id, record)| {
+        .entities_any(&["REPRESENTATION", "SHAPE_REPRESENTATION"])
+        .filter_map(|(id, record)| {
             if !matches!(
                 record.simple_name(),
                 Some("REPRESENTATION" | "SHAPE_REPRESENTATION")
@@ -42,9 +50,8 @@ pub(super) fn decode(
         })
         .collect::<BTreeMap<_, _>>();
     let properties = exchange
-        .records
-        .iter()
-        .filter_map(|(&id, record)| {
+        .entities("PROPERTY_DEFINITION")
+        .filter_map(|(id, record)| {
             if record.simple_name() == Some("PROPERTY_DEFINITION")
                 && record
                     .parameter(0)?
@@ -70,10 +77,7 @@ pub(super) fn decode(
     let mut notes = Vec::new();
     let mut warnings = Vec::new();
 
-    for (&relation_id, relation) in &exchange.records {
-        if relation.simple_name() != Some("PROPERTY_DEFINITION_REPRESENTATION") {
-            continue;
-        }
+    for (relation_id, relation) in exchange.entities("PROPERTY_DEFINITION_REPRESENTATION") {
         let Some(property_id) = relation.parameter(0).and_then(ValueExt::reference) else {
             continue;
         };
@@ -128,20 +132,22 @@ pub(super) fn decode(
         }
     }
     let mut referenced_validation_points = BTreeSet::new();
-    for (&record_id, record) in &exchange.records {
-        if validation_representations.contains(&record_id) {
-            continue;
-        }
-        for value in record
-            .partials
-            .iter()
-            .flat_map(|partial| &partial.parameters)
-        {
-            collect_validation_references(
-                value,
-                &validation_points,
-                &mut referenced_validation_points,
-            );
+    if !validation_points.is_empty() {
+        for (&record_id, record) in &exchange.records {
+            if validation_representations.contains(&record_id) {
+                continue;
+            }
+            for value in record
+                .partials
+                .iter()
+                .flat_map(|partial| &partial.parameters)
+            {
+                collect_validation_references(
+                    value,
+                    &validation_points,
+                    &mut referenced_validation_points,
+                );
+            }
         }
     }
     ir.model.points.retain(|point| {

--- a/crates/cadmpeg-ir/src/draft.rs
+++ b/crates/cadmpeg-ir/src/draft.rs
@@ -144,6 +144,7 @@ pub enum DraftError {
 pub struct ModelDraft {
     model: Model,
     identities: HashSet<String>,
+    identities_synced: bool,
     exactness: BTreeMap<String, ExactnessNote>,
     notes: Vec<LossNote>,
     ledger: TransferLedger,
@@ -152,7 +153,10 @@ pub struct ModelDraft {
 impl ModelDraft {
     /// Creates an empty draft.
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            identities_synced: true,
+            ..Self::default()
+        }
     }
 
     /// Inserts one entity, rejecting draft-local identity collisions immediately.
@@ -172,6 +176,7 @@ impl ModelDraft {
 
     /// Returns the mutable staged arena for one entity type.
     pub fn arena_mut<T: ArenaEntity>(&mut self) -> &mut Vec<T> {
+        self.identities_synced = false;
         T::arena_mut(&mut self.model)
     }
 
@@ -185,6 +190,7 @@ impl ModelDraft {
     /// Commit still checks all identities and references, including entities inserted
     /// through this lower-level surface.
     pub fn model_mut(&mut self) -> &mut Model {
+        self.identities_synced = false;
         &mut self.model
     }
 
@@ -234,35 +240,37 @@ impl ModelDraft {
         )
     }
 
-    fn validate_against(&self, base: &CadIr) -> Result<(), DraftError> {
+    fn validate_against(&mut self, base: &CadIr) -> Result<(), DraftError> {
         let index = ModelIndex::new(base);
         self.validate_with_contains(|identity| index.contains(identity))
-            .map(|_| ())
     }
 
     /// Validates staged identities and references against one identity universe.
     ///
     /// The caller supplies the identities already committed outside this draft;
     /// references may also target another entity staged in the same draft. The
-    /// returned set owns the identities collected from every arena so a session
-    /// can absorb it after the commit without allocating them again.
+    /// identity set populated by `insert` is reused. Direct mutable staging
+    /// invalidates that set and causes one complete rebuild before validation.
     fn validate_with_contains(
-        &self,
+        &mut self,
         contains: impl Fn(&str) -> bool,
-    ) -> Result<HashSet<String>, DraftError> {
-        let mut staged_identities = HashSet::with_capacity(self.model.entity_count());
-        macro_rules! collect_staged_identities {
-            ($($field:ident: $ty:ty, $doc:literal, [$($attribute:meta),*];)*) => {
-                $(for entity in &self.model.$field {
-                    let identity = entity.identity().to_owned();
-                    if !staged_identities.insert(identity.clone()) {
-                        return Err(DraftError::IdentityCollision(identity));
-                    }
-                })*
-            };
+    ) -> Result<(), DraftError> {
+        if !self.identities_synced {
+            self.identities.clear();
+            macro_rules! collect_staged_identities {
+                ($($field:ident: $ty:ty, $doc:literal, [$($attribute:meta),*];)*) => {
+                    $(for entity in &self.model.$field {
+                        let identity = entity.identity().to_owned();
+                        if !self.identities.insert(identity.clone()) {
+                            return Err(DraftError::IdentityCollision(identity));
+                        }
+                    })*
+                };
+            }
+            crate::document::arena_registry!(collect_staged_identities);
+            self.identities_synced = true;
         }
-        crate::document::arena_registry!(collect_staged_identities);
-        for identity in &staged_identities {
+        for identity in &self.identities {
             if contains(identity) {
                 return Err(DraftError::IdentityCollision(identity.clone()));
             }
@@ -275,7 +283,7 @@ impl ModelDraft {
                     entity.visit_references(&mut |reference| {
                         if missing.is_none()
                             && !contains(&reference.target)
-                            && !staged_identities.contains(&reference.target)
+                            && !self.identities.contains(&reference.target)
                         {
                             missing = Some(reference.target);
                         }
@@ -290,19 +298,19 @@ impl ModelDraft {
             };
         }
         crate::document::arena_registry!(validate_arenas);
-        Ok(staged_identities)
+        Ok(())
     }
 
     /// Validates and atomically extends a document, annotations, notes, and ledger.
     pub fn commit(
-        self,
+        mut self,
         base: &mut CadIr,
         annotations: &mut Annotations,
         notes: &mut Vec<LossNote>,
         ledger: &mut TransferLedger,
     ) -> Result<(), DraftError> {
         self.validate_against(base)?;
-        self.commit_validated(base, annotations, notes, ledger);
+        let _ = self.commit_validated(base, annotations, notes, ledger);
         Ok(())
     }
 
@@ -330,6 +338,7 @@ impl ModelDraft {
             };
         }
         crate::document::arena_registry!(collect_identities);
+        self.identities_synced = false;
         self.exactness
             .retain(|identity, _| self.identities.contains(identity));
         self.commit(base, annotations, notes, ledger)
@@ -341,10 +350,11 @@ impl ModelDraft {
         annotations: &mut Annotations,
         notes: &mut Vec<LossNote>,
         ledger: &mut TransferLedger,
-    ) {
+    ) -> HashSet<String> {
         let Self {
             mut model,
-            identities: _,
+            identities,
+            identities_synced: _,
             exactness,
             notes: staged_notes,
             ledger: staged_ledger,
@@ -358,6 +368,7 @@ impl ModelDraft {
         annotations.exactness.extend(exactness);
         notes.extend(staged_notes);
         ledger.entries.extend(staged_ledger.entries);
+        identities
     }
 }
 
@@ -410,10 +421,13 @@ impl CommitSession {
     /// success, the draft's owned identities are moved into this session. A
     /// rejected draft therefore leaves both the document and the session
     /// unchanged and does not poison a later commit.
-    pub fn commit_model(&mut self, draft: ModelDraft, base: &mut CadIr) -> Result<(), DraftError> {
-        let staged_identities =
-            draft.validate_with_contains(|identity| self.identities.contains(identity))?;
-        draft.commit_validated(
+    pub fn commit_model(
+        &mut self,
+        mut draft: ModelDraft,
+        base: &mut CadIr,
+    ) -> Result<(), DraftError> {
+        draft.validate_with_contains(|identity| self.identities.contains(identity))?;
+        let staged_identities = draft.commit_validated(
             base,
             &mut Annotations::default(),
             &mut Vec::new(),
@@ -531,6 +545,64 @@ mod tests {
         assert!(annotations.exactness.is_empty());
         assert!(notes.is_empty());
         assert!(ledger.is_empty());
+    }
+
+    #[test]
+    fn direct_model_staging_rebuilds_identity_cache_before_commit() {
+        let identity = "test:model:point#direct-duplicate";
+        let mut draft = ModelDraft::new();
+        draft.model_mut().points.push(point(identity));
+        draft.model_mut().points.push(point(identity));
+        let mut ir = CadIr::empty(Units::default());
+
+        assert_eq!(
+            draft.commit_model(&mut ir),
+            Err(DraftError::IdentityCollision(identity.into()))
+        );
+        assert!(ir.model.points.is_empty());
+    }
+
+    #[test]
+    fn direct_model_staging_revalidates_references_before_commit() {
+        let owner = "test:model:vertex#direct-missing";
+        let target = "test:model:point#direct-missing";
+        let mut draft = ModelDraft::new();
+        draft.model_mut().vertices.push(Vertex {
+            id: owner.into(),
+            point: target.into(),
+            tolerance: None,
+        });
+        let mut ir = CadIr::empty(Units::default());
+
+        assert_eq!(
+            draft.commit_model(&mut ir),
+            Err(DraftError::UnresolvedReference {
+                owner: owner.into(),
+                target: target.into(),
+            })
+        );
+        assert!(ir.model.vertices.is_empty());
+    }
+
+    #[test]
+    fn incomplete_commit_rechecks_duplicate_identities() {
+        let identity = "test:model:point#incomplete-duplicate";
+        let mut draft = ModelDraft::new();
+        draft.model_mut().points.push(point(identity));
+        draft.model_mut().points.push(point(identity));
+        let mut ir = CadIr::empty(Units::default());
+
+        assert_eq!(
+            draft.commit_incomplete(
+                &mut ir,
+                &mut Annotations::default(),
+                &mut Vec::new(),
+                &mut TransferLedger::default(),
+                |_, _| true,
+            ),
+            Err(DraftError::IdentityCollision(identity.into()))
+        );
+        assert!(ir.model.points.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Stream STEP lexing directly into the parser so decode no longer retains the full token vector alongside the parsed record graph.
- Add a persistent entity-type index with cached multi-type unions, then use indexed candidate lists and empty-domain gates in PMI, validation, and topology discovery.
- Memoize recursive edge and shell definition resolution, and remove the redundant post-topology carrier-index rebuild.
- Reuse draft identity state and move it into the commit session while retaining per-draft reference validation, salvage behavior, and collision checks.

## Verification

- cargo fmt --all --check
- cargo clippy --workspace -- -D warnings -W missing-docs
- cargo test-fast (exit 0)
- cargo build -p cadmpeg --release
- Scoped pre-commit clippy and tests passed, including 157 STEP tests and 200 IR tests.
- cadmpeg validate reports 0 errors and 0 warnings on the large STEP benchmark output.
- Output SHA-256 and model census are unchanged; the two optimized outputs compare byte-for-byte identical.

## Benchmark

Two runs of the 56.3 MiB STEP benchmark:

- Wall time: 4.24 s and 4.43 s, versus 6.15 s and 5.48 s in the baseline report.
- Peak RSS: 1,003,908 KiB and 1,003,544 KiB, versus approximately 1,288,756 KiB.
- Average wall time improved by approximately 25%; peak RSS decreased by approximately 22%.

The draft-validation change deliberately does not batch away reference traversal: that would alter per-body salvage and failure semantics.