### PR TITLE
Fix subtract overflow in CATIA a5 surface decode

### DIFF
--- a/crates/cadmpeg-codec-catia/src/families/a5a8/records.rs
+++ b/crates/cadmpeg-codec-catia/src/families/a5a8/records.rs
@@ -1611,7 +1611,7 @@ fn strictly_increasing_finite(values: &[f64]) -> bool {
 }
 
 fn a5_int(byte: u8) -> Option<u32> {
-    (byte % 4 == 1).then_some(((byte - 1) / 4) as u32)
+    (byte % 4 == 1).then(|| u32::from((byte - 1) / 4))
 }
 
 fn a5_array_marker(bytes: &[u8], at: usize) -> Option<usize> {

--- a/crates/cadmpeg-codec-catia/src/families/a5a8/tests.rs
+++ b/crates/cadmpeg-codec-catia/src/families/a5a8/tests.rs
@@ -660,6 +660,14 @@ fn a5_surface_parser_rejects_zero_tail_codes_without_underflow() {
 }
 
 #[test]
+fn a5_surface_parser_rejects_untagged_int_bytes_without_underflow() {
+    let bytes = [
+        0xa5, 0xa5, 0x03, 0x34, 0, 0, 0, 0, 0, 0, 0, 0xa5, 0xb3, 0xa5, 0xa5, 0xb3, 0xb3, 0xa5,
+    ];
+    assert!(crate::families::a5a8::records::a5_surfaces(&bytes).is_empty());
+}
+
+#[test]
 fn a5_surface_parser_accepts_each_structured_tail_variant() {
     for tail in [
         a5_surface_short_tail(),


### PR DESCRIPTION
The fuzz smoke workflow crashed in the catia_a5_surfaces target: a5_int used bool::then_some, which evaluates its argument eagerly, so an untagged byte (byte % 4 != 1) still executed byte - 1. A 0x00 degree byte underflowed u8 and panicked under the fuzz profile's overflow checks, violating the no-panic fuzz contract.

Switch to the lazy bool::then so the subtraction runs only for tagged bytes. Add a regression test that feeds the fuzzer's crash input through a5_surfaces, the same entry point the fuzz target exercises.

<!-- SPDX-License-Identifier: CC-BY-4.0 -->

## Summary

- Fix subtract overflow in CATIA a5 surface decode

## Checklist

- [x] Signed off — every commit (`git commit -s`), or one `Signed-off-by` line in this PR description. See [CONTRIBUTING.md](../CONTRIBUTING.md).

## Provenance declaration (decoder or format-spec changes only)

<!-- Required verbatim for changes under crates/cadmpeg-codec-* or docs/formats/.
     See LEGAL.md for what sources are allowed.
     Delete this section for tooling/IR/exporter/test/docs-only PRs. -->

I derived the format knowledge in this contribution only from sources allowed by LEGAL.md.
