### PR TITLE
Skip seed-generator bins in nightly fuzz smoke

### DIFF
--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -51,7 +51,14 @@ jobs:
 
       - name: Run each fuzz target briefly
         run: |
+          # cargo-fuzz lists every [[bin]], including seed generators under
+          # src/bin/. Those are Cargo utilities, not libFuzzer harnesses
+          # (crates/cadmpeg-fuzz/README.md). generate_fcstd_seeds reads a
+          # corpus fixture relative to CWD and exits 1 from the repo root.
           for t in $(cargo +nightly fuzz list --fuzz-dir crates/cadmpeg-fuzz); do
+            if [ ! -f "crates/cadmpeg-fuzz/fuzz_targets/${t}.rs" ]; then
+              continue
+            fi
             seed_dir="crates/cadmpeg-fuzz/seeds/$t"
             if [ ! -d "$seed_dir" ] && [ -d "seeds/$t" ]; then
               seed_dir="seeds/$t"


### PR DESCRIPTION
cargo-fuzz lists generate_* utilities as targets. generate_fcstd_seeds then fails from the repo root because its corpus fixture path is CWD-relative.

<!-- SPDX-License-Identifier: CC-BY-4.0 -->

## Summary

- Skip seed-generator bins in nightly fuzz smoke

## Checklist

- [x] Signed off — every commit (`git commit -s`), or one `Signed-off-by` line in this PR description. See [CONTRIBUTING.md](../CONTRIBUTING.md).

## Provenance declaration (decoder or format-spec changes only)

<!-- Required verbatim for changes under crates/cadmpeg-codec-* or docs/formats/.
     See LEGAL.md for what sources are allowed.
     Delete this section for tooling/IR/exporter/test/docs-only PRs. -->

I derived the format knowledge in this contribution only from sources allowed by LEGAL.md.
