### PR TITLE
Fix SLDPRT DisplayLists face table sequence bounds

### DIFF
--- a/crates/cadmpeg-codec-sldprt/src/tessellation.rs
+++ b/crates/cadmpeg-codec-sldprt/src/tessellation.rs
@@ -325,7 +325,6 @@ fn parse_table(bytes: &[u8], mut at: usize) -> Option<(Mesh, usize)> {
 
 pub(crate) fn section_display_faces(section: Section<'_>) -> Vec<DisplayFace> {
     let payload = section.payload();
-    let classes = class_intervals(payload);
     let markers = payload
         .windows(FACE_TESSELLATION_CLASS.len())
         .enumerate()
@@ -340,18 +339,14 @@ pub(crate) fn section_display_faces(section: Section<'_>) -> Vec<DisplayFace> {
         ) else {
             continue;
         };
-        let limit = classes
-            .iter()
-            .find(|class| class.name == "uoTempFaceTessData_c" && class.class_offset + 6 == marker)
-            .map_or_else(
-                || {
-                    markers
-                        .get(marker_index + 1)
-                        .copied()
-                        .unwrap_or(payload.len())
-                },
-                |class| class.content.end,
-            );
+        // `uoBodyPropInfo_c` declarations separate body-property groups, but
+        // face descriptor tables continue after them without repeating the
+        // `uoTempFaceTessData_c` declaration. Only another face declaration
+        // starts a new sequence.
+        let limit = markers
+            .get(marker_index + 1)
+            .copied()
+            .unwrap_or(payload.len());
         let start = header + descriptor_table_offset(payload, header);
         let Some(tables) = parse_table_sequence(payload, start, limit) else {
             continue;

--- a/crates/cadmpeg-codec-sldprt/src/tessellation/tests.rs
+++ b/crates/cadmpeg-codec-sldprt/src/tessellation/tests.rs
@@ -116,6 +116,48 @@ fn extended_face_tessellation_header_places_table_at_plus_40() {
 }
 
 #[test]
+fn body_property_class_does_not_end_face_table_sequence() {
+    let mut payload = Vec::new();
+    class(&mut payload, "uoTempFaceTessData_c", &[]);
+    payload.extend(1_u32.to_le_bytes());
+    payload.extend(1_u32.to_le_bytes());
+    payload.extend(table());
+
+    class(&mut payload, "uoBodyPropInfo_c", &[]);
+    payload.extend([0x37, 0x80]);
+    payload.extend(1_u32.to_le_bytes());
+    payload.extend(1_u32.to_le_bytes());
+    payload.extend(table());
+
+    let mut source = sldprt_with_body(&triangle_body());
+    source.extend(make_block(0x41, "Contents/DisplayLists", &payload));
+    let result = SldprtCodec
+        .decode(&mut Cursor::new(source), &DecodeOptions::default())
+        .unwrap();
+
+    assert_eq!(result.ir().model.tessellations.len(), 2);
+}
+
+#[test]
+fn next_face_class_ends_face_table_sequence() {
+    let mut payload = Vec::new();
+    for _ in 0..2 {
+        class(&mut payload, "uoTempFaceTessData_c", &[]);
+        payload.extend(1_u32.to_le_bytes());
+        payload.extend(1_u32.to_le_bytes());
+        payload.extend(table());
+    }
+
+    let mut source = sldprt_with_body(&triangle_body());
+    source.extend(make_block(0x41, "Contents/DisplayLists", &payload));
+    let result = SldprtCodec
+        .decode(&mut Cursor::new(source), &DecodeOptions::default())
+        .unwrap();
+
+    assert_eq!(result.ir().model.tessellations.len(), 2);
+}
+
+#[test]
 fn incomplete_extended_header_does_not_shift_the_table() {
     let mut payload = Vec::new();
     for word in [1_u32, 1, 1, 0, 0, 0, 0, 0, 0, 0] {

--- a/docs/formats/sldprt.md
+++ b/docs/formats/sldprt.md
@@ -1469,6 +1469,8 @@ The offset surface retains the support parameterization. Nested offset carriers 
 
   A table ends at the end of its sixth descriptor payload. The following framed metadata belongs to that table until the next validated table starts.
 
+  A `uoBodyPropInfo_c` class declaration separates body-property groups inside the face-table sequence. Face descriptor tables continue after that declaration without another `uoTempFaceTessData_c` declaration. A following `uoTempFaceTessData_c` declaration, or the end of the `DisplayLists` payload when there is no following declaration, ends the sequence.
+
   A `uoTempFaceTessData_c` class token has two table-header forms. Offsets are from the byte after the class token. Both forms start with the first table's triangle count as u32 LE at `+0` and strip count as u32 LE at `+4`. These values equal `C - 2*N` and `N` for that table. In the compact form, the first descriptor starts at `+8`. The extended form has u32 LE values `1`, `0`, `0`, and one nonzero token at `+8`, `+12`, `+16`, and `+20`, followed by 16 zero bytes at `+24`; its first descriptor starts at `+40`. The fixed cells and nonzero token select the extended form. A header that does not satisfy the complete extended grammar uses the compact offset and must frame a valid descriptor table there.
 
   Every position in one face-tessellation table lies on its owning B-rep face support surface. The f32 coordinate precision limits this incidence test. When exactly one B-rep face has an analytic support incident to all table positions, that face owns the table and its body is the face's topological owner.


### PR DESCRIPTION
<!-- SPDX-License-Identifier: CC-BY-4.0 -->

## Summary

- Continue scanning SLDPRT face descriptor tables across `uoBodyPropInfo_c` declarations.
- Bound each face-table sequence by the next `uoTempFaceTessData_c` declaration or the end of the `DisplayLists` payload.
- Document the byte-level sequence boundary.
- Add regression tests for both boundary conditions.

## Problem

The class interval bound added while binding DisplayLists appearances in #131 treats the following class declaration as the end of a face-table sequence.

However, `uoBodyPropInfo_c` separates body-property groups within that sequence. Additional face descriptor tables can follow it without another `uoTempFaceTessData_c` declaration. Those tables were therefore skipped during tessellation decoding.

## Fix

Use the next `uoTempFaceTessData_c` declaration, or the end of the payload, as the sequence boundary.

The existing strict descriptor-table validation remains unchanged and continues to act as the admission gate for tables found within the sequence.

## Validation

- `cargo test -q -p cadmpeg-codec-sldprt`
- `cargo test-fast`
- `cargo test -q -p cadmpeg --test layout_tables`
- `scripts/convergence-ratchet.py`
- `cargo fmt --all --check`
- `git diff --check`

## Checklist

- [x] Signed off — every commit (`git commit -s`), or one `Signed-off-by` line in this PR description. See [CONTRIBUTING.md](../CONTRIBUTING.md).

## Provenance declaration

I derived the format knowledge in this contribution only from sources allowed by LEGAL.md.
